### PR TITLE
feat: parameterize mutation operators with `mutation_rate`

### DIFF
--- a/example/src/ga.rs
+++ b/example/src/ga.rs
@@ -19,7 +19,6 @@ pub fn point_generator(restrictions: &Vec<(f64, f64)>) -> Vec<f64> {
 pub fn ga_example() {
   let res = ecrs::ga::Builder::new()
     .set_max_generation_count(500)
-    .set_mutation_rate(0.5f64)
 		.set_population_size(100)
 		.set_fitness_fn(rastrigin::rastrigin_fitness)
 		.set_crossover_operator(Box::new(ga::operators::crossover::SinglePoint::new()))

--- a/src/ga.rs
+++ b/src/ga.rs
@@ -25,7 +25,6 @@ type FitnessFn<S> = fn(&S) -> f64;
 type PopulationGenerator<S> = fn(usize) -> Vec<S>;
 
 pub struct GAParams {
-  pub mutation_rate: f64,
   pub selection_rate: f64,
   pub generation_upper_bound: usize,
   pub population_size: usize,
@@ -35,7 +34,6 @@ pub struct GAParams {
 impl Default for GAParams {
 	fn default() -> Self {
 		Self {
-        mutation_rate: 0.08f64,
         selection_rate: 0.5f64,
         generation_upper_bound: 200,
         population_size: 100,

--- a/src/ga/builder.rs
+++ b/src/ga/builder.rs
@@ -51,12 +51,6 @@ impl<T: Chromosome, S: ChromosomeWrapper<T>> Builder<T, S> {
     }
   }
 
-  pub fn set_mutation_rate(mut self, mutation_rate: f64) -> Self {
-    debug_assert!((0f64..=1f64).contains(&mutation_rate));
-		self.config.params = self.config.params.map(|mut params| {params.mutation_rate = mutation_rate; params});
-    self
-  }
-
   pub fn set_selection_rate(mut self, selection_rate: f64) -> Self {
     debug_assert!((0f64..=1f64).contains(&selection_rate));
 		self.config.params = self.config.params.map(|mut params| {params.selection_rate = selection_rate; params});


### PR DESCRIPTION
<!-- If applicable - remeber to add the PR to the EA Rust project (ONLY IF THERE IS NO LINKED ISSUE) -->

## Description

Move `mutation_rate` param from `GAConfig` to mutation operator configuration.

## Linked issues

Resolves #130 
