### PR TITLE
feat: better defaults for GA builder

### DIFF
--- a/example/src/ga.rs
+++ b/example/src/ga.rs
@@ -1,5 +1,6 @@
 pub mod rastrigin;
 pub mod sum_of_squares;
+pub mod wordmax;
 
 use ecrs::ga;
 
@@ -16,7 +17,7 @@ pub fn point_generator(restrictions: &Vec<(f64, f64)>) -> Vec<f64> {
 }
 
 pub fn ga_example() {
-  let res = ecrs::ga::GenericBuilder::new()
+  let res = ecrs::ga::Builder::new()
     .set_max_generation_count(500)
     .set_population_size(100)
     .set_fitness_fn(rastrigin::rastrigin_fitness)
@@ -32,4 +33,20 @@ pub fn ga_example() {
     .run();
 
   println!("{:?}", res);
+}
+
+pub fn ga_rvc_example() -> Option<ga::Individual<Vec<f64>>> {
+	ecrs::ga::Builder::with_rvc()
+		.fitness_fn(rastrigin::rastrigin_fitness)
+		.dim(5)
+		.build()
+		.run()
+}
+
+pub fn ga_bsc_example() -> Option<ga::Individual<Vec<bool>>> {
+	ecrs::ga::Builder::with_bsc()
+		.fitness_fn(wordmax::wordmax_fitness)
+		.dim(10)
+		.build()
+		.run()
 }

--- a/example/src/ga.rs
+++ b/example/src/ga.rs
@@ -16,7 +16,7 @@ pub fn point_generator(restrictions: &Vec<(f64, f64)>) -> Vec<f64> {
 }
 
 pub fn ga_example() {
-  let res = ecrs::ga::Builder::new()
+  let res = ecrs::ga::GenericBuilder::new()
     .set_max_generation_count(500)
     .set_population_size(100)
     .set_fitness_fn(rastrigin::rastrigin_fitness)

--- a/example/src/ga.rs
+++ b/example/src/ga.rs
@@ -36,17 +36,17 @@ pub fn ga_example() {
 }
 
 pub fn ga_rvc_example() -> Option<ga::Individual<Vec<f64>>> {
-	ecrs::ga::Builder::with_rvc()
-		.fitness_fn(rastrigin::rastrigin_fitness)
-		.dim(5)
-		.build()
-		.run()
+  ecrs::ga::Builder::with_rvc()
+    .fitness_fn(rastrigin::rastrigin_fitness)
+    .dim(5)
+    .build()
+    .run()
 }
 
 pub fn ga_bsc_example() -> Option<ga::Individual<Vec<bool>>> {
-	ecrs::ga::Builder::with_bsc()
-		.fitness_fn(wordmax::wordmax_fitness)
-		.dim(10)
-		.build()
-		.run()
+  ecrs::ga::Builder::with_bsc()
+    .fitness_fn(wordmax::wordmax_fitness)
+    .dim(10)
+    .build()
+    .run()
 }

--- a/example/src/ga/wordmax.rs
+++ b/example/src/ga/wordmax.rs
@@ -1,5 +1,5 @@
 use ecrs::ga::{individual, Individual};
 
 pub fn wordmax_fitness(individual: &Individual<Vec<bool>>) -> f64 {
-	individual.chromosome_ref().into_iter().filter(|gene| **gene == true).count() as f64
+  individual.chromosome_ref().iter().filter(|gene| **gene).count() as f64
 }

--- a/example/src/ga/wordmax.rs
+++ b/example/src/ga/wordmax.rs
@@ -1,4 +1,4 @@
-use ecrs::ga::{individual, Individual};
+use ecrs::ga::Individual;
 
 pub fn wordmax_fitness(individual: &Individual<Vec<bool>>) -> f64 {
   individual.chromosome_ref().iter().filter(|gene| **gene).count() as f64

--- a/example/src/ga/wordmax.rs
+++ b/example/src/ga/wordmax.rs
@@ -1,0 +1,5 @@
+use ecrs::ga::{individual, Individual};
+
+pub fn wordmax_fitness(individual: &Individual<Vec<bool>>) -> f64 {
+	individual.chromosome_ref().into_iter().filter(|gene| **gene == true).count() as f64
+}

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -42,6 +42,6 @@ fn main() {
 
   ga::ga_example();
 
-	ga::ga_rvc_example();
-	ga::ga_bsc_example();
+  ga::ga_rvc_example();
+  ga::ga_bsc_example();
 }

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -41,4 +41,7 @@ fn main() {
   };
 
   ga::ga_example();
+
+	ga::ga_rvc_example();
+	ga::ga_bsc_example();
 }

--- a/src/ga/builder.rs
+++ b/src/ga/builder.rs
@@ -1,3 +1,5 @@
+pub mod realvalued;
+
 use super::individual::Chromosome;
 use super::operators::selection::SelectionOperator;
 use super::population::PopulationGenerator;
@@ -86,96 +88,7 @@ where
 // 	}
 // }
 
-pub struct RealValuedBuilder<M, C, S, P, Pr>
-where
-  M: MutationOperator<Vec<f64>>,
-  C: CrossoverOperator<Vec<f64>>,
-  S: SelectionOperator<Vec<f64>>,
-  P: PopulationGenerator<Vec<f64>>,
-  Pr: Probe<Vec<f64>>,
-{
-  config: GAConfigOpt<Vec<f64>, M, C, S, P, Pr>,
-}
-
-impl<M, C, S, P, Pr> RealValuedBuilder<M, C, S, P, Pr>
-where
-  M: MutationOperator<Vec<f64>>,
-  C: CrossoverOperator<Vec<f64>>,
-  S: SelectionOperator<Vec<f64>>,
-  P: PopulationGenerator<Vec<f64>>,
-  Pr: Probe<Vec<f64>>,
-{
-  pub fn set_selection_rate(mut self, selection_rate: f64) -> Self {
-    debug_assert!((0f64..=1f64).contains(&selection_rate));
-    self.config.params = self.config.params.map(|mut params| {
-      params.selection_rate = selection_rate;
-      params
-    });
-    self
-  }
-
-  pub fn set_max_duration(mut self, max_duration: std::time::Duration) -> Self {
-    self.config.params = self.config.params.map(|mut params| {
-      params.max_duration = Some(max_duration);
-      params
-    });
-    self
-  }
-
-  pub fn set_max_generation_count(mut self, max_gen_count: usize) -> Self {
-    debug_assert!(max_gen_count >= 1);
-    self.config.params = self.config.params.map(|mut params| {
-      params.generation_upper_bound = max_gen_count;
-      params
-    });
-    self
-  }
-
-  pub fn set_population_size(mut self, size: usize) -> Self {
-    debug_assert!(size > 0);
-    self.config.params = self.config.params.map(|mut params| {
-      params.population_size = size;
-      params
-    });
-    self
-  }
-
-  pub fn set_fitness_fn(mut self, fitness_fn: FitnessFn<Individual<Vec<f64>>>) -> Self {
-    self.config.fitness_fn = Some(fitness_fn);
-    self
-  }
-
-  pub fn set_mutation_operator(mut self, mutation_op: M) -> Self {
-    self.config.mutation_operator = Some(mutation_op);
-    self
-  }
-
-  pub fn set_crossover_operator(mut self, crossover_op: C) -> Self {
-    self.config.crossover_operator = Some(crossover_op);
-    self
-  }
-
-  pub fn set_selection_operator(mut self, selection_op: S) -> Self {
-    self.config.selection_operator = Some(selection_op);
-    self
-  }
-
-  pub fn set_population_generator(mut self, generator: P) -> Self {
-    self.config.population_factory = Some(generator);
-    self
-  }
-
-  pub fn set_probe(mut self, probe: Pr) -> Self {
-    self.config.probe = Some(probe);
-    self
-  }
-
-  pub fn build(self) -> GeneticAlgorithm<Vec<f64>, M, C, S, P, Pr> {
-    GeneticAlgorithm::new(self.config.into())
-  }
-}
-
-pub struct Builder<T, M, C, S, P, Pr>
+pub struct GenericBuilder<T, M, C, S, P, Pr>
 where
   T: Chromosome,
   M: MutationOperator<T>,
@@ -187,7 +100,7 @@ where
   config: GAConfigOpt<T, M, C, S, P, Pr>,
 }
 
-impl<T, M, C, S, P, Pr> Builder<T, M, C, S, P, Pr>
+impl<T, M, C, S, P, Pr> GenericBuilder<T, M, C, S, P, Pr>
 where
   T: Chromosome,
   M: MutationOperator<T>,
@@ -197,7 +110,7 @@ where
   Pr: Probe<T>,
 {
   pub fn new() -> Self {
-    Builder {
+    GenericBuilder {
       config: GAConfigOpt::new(),
     }
   }

--- a/src/ga/builder.rs
+++ b/src/ga/builder.rs
@@ -7,6 +7,8 @@ use super::{
   CrossoverOperator, FitnessFn, GAConfig, GAParams, GeneticAlgorithm, Individual, MutationOperator, Probe,
 };
 
+pub use presets::{BitStringBuilder, RealValuedBuilder};
+
 struct GAConfigOpt<T, M, C, S, P, Pr>
 where
   T: Chromosome,

--- a/src/ga/builder.rs
+++ b/src/ga/builder.rs
@@ -1,5 +1,7 @@
 pub mod presets;
 
+use std::marker::PhantomData;
+
 use super::individual::Chromosome;
 use super::operators::selection::SelectionOperator;
 use super::population::PopulationGenerator;
@@ -71,24 +73,30 @@ where
   }
 }
 
-// pub struct BuilderDispatcher;
+pub struct Builder;
 
-// impl BuilderDispatcher {
-// 	pub fn with_real_valued_chromosome<M, C, S, P, Pr>() -> Builder<Vec<f64>, M, C, S, P, Pr>
-// 	where
-// 		M: MutationOperator<Vec<f64>>,
-// 		C: CrossoverOperator<Vec<f64>>,
-// 		S: SelectionOperator<Vec<f64>>,
-// 		P: PopulationGenerator<Vec<f64>>,
-// 		Pr: Probe<Vec<f64>>,
-// 	{
-// 		Builder::new()
-// 	}
+impl Builder {
+	#[allow(clippy::new_ret_no_self)]
+	pub fn new<T, M, C, S, P, Pr>() -> GenericBuilder<T, M, C, S, P, Pr>
+	where
+		T: Chromosome,
+		M: MutationOperator<T>,
+		C: CrossoverOperator<T>,
+		S: SelectionOperator<T>,
+		P: PopulationGenerator<T>,
+		Pr: Probe<T>
+	{
+		GenericBuilder::new()
+	}
 
-// 	pub fn with_bitstring_chromosome() -> Builder<Vec<bool>, Identity, SinglePoint, StochasticUniversalSampling, BitStrings, EmptyProbe> {
-// 		Builder::new()
-// 	}
-// }
+	pub fn with_rvc() -> RealValuedBuilder {
+		RealValuedBuilder::new()
+	}
+
+	pub fn with_bsc() -> BitStringBuilder {
+		BitStringBuilder::new()
+	}
+}
 
 pub struct GenericBuilder<T, M, C, S, P, Pr>
 where

--- a/src/ga/builder.rs
+++ b/src/ga/builder.rs
@@ -1,4 +1,7 @@
+use std::ops::Index;
+
 use super::individual::Chromosome;
+use super::operators::mutation::Identity;
 use super::operators::selection::SelectionOperator;
 use super::population::PopulationGenerator;
 use super::{
@@ -23,10 +26,31 @@ where
   probe: Option<Pr>,
 }
 
-impl<T, M, C, S, P, Pr> Default for GAConfigOpt<T, M, C, S, P, Pr>
+impl<T, M, C, S, P, Pr> GAConfigOpt<T, M, C, S, P, Pr>
 where
-  T: Chromosome,
-  M: MutationOperator<T>,
+	T: Chromosome,
+	M: MutationOperator<T>,
+	C: CrossoverOperator<T>,
+	S: SelectionOperator<T>,
+	P: PopulationGenerator<T>,
+	Pr: Probe<T>
+{
+	pub fn new() -> Self {
+    Self {
+      params: Some(GAParams::default()),
+      fitness_fn: None,
+      mutation_operator: None,
+      crossover_operator: None,
+      selection_operator: None,
+      population_factory: None,
+      probe: None,
+    }
+  }
+}
+
+impl<T, C, S, P, Pr> Default for GAConfigOpt<T, Identity, C, S, P, Pr>
+where
+  T: Chromosome + Index<usize>,
   C: CrossoverOperator<T>,
   S: SelectionOperator<T>,
   P: PopulationGenerator<T>,
@@ -36,7 +60,7 @@ where
     Self {
       params: Some(GAParams::default()),
       fitness_fn: None,
-      mutation_operator: None,
+      mutation_operator: Some(Identity::new()),
       crossover_operator: None,
       selection_operator: None,
       population_factory: None,
@@ -79,6 +103,19 @@ where
   config: GAConfigOpt<T, M, C, S, P, Pr>,
 }
 
+impl<T, C, S, P, Pr> Default for Builder<T, Identity, C, S, P, Pr>
+where
+	T: Chromosome + Index<usize>,
+	C: CrossoverOperator<T>,
+	S: SelectionOperator<T>,
+	P: PopulationGenerator<T>,
+	Pr: Probe<T>
+{
+	fn default() -> Self {
+		Self { config: Default::default() }
+	}
+}
+
 impl<T, M, C, S, P, Pr> Builder<T, M, C, S, P, Pr>
 where
   T: Chromosome,
@@ -90,7 +127,7 @@ where
 {
   pub fn new() -> Self {
     Builder {
-      config: GAConfigOpt::default(),
+      config: GAConfigOpt::new(),
     }
   }
 

--- a/src/ga/builder.rs
+++ b/src/ga/builder.rs
@@ -1,6 +1,6 @@
 use super::individual::Chromosome;
-use super::operators::selection::{SelectionOperator, StochasticUniversalSampling, Boltzmann};
-use super::population::{PopulationGenerator, RandomPoints, BitStrings};
+use super::operators::selection::SelectionOperator;
+use super::population::PopulationGenerator;
 use super::{
   CrossoverOperator, FitnessFn, GAConfig, GAParams, GeneticAlgorithm, Individual, MutationOperator, Probe,
 };
@@ -25,14 +25,14 @@ where
 
 impl<T, M, C, S, P, Pr> GAConfigOpt<T, M, C, S, P, Pr>
 where
-	T: Chromosome,
-	M: MutationOperator<T>,
-	C: CrossoverOperator<T>,
-	S: SelectionOperator<T>,
-	P: PopulationGenerator<T>,
-	Pr: Probe<T>
+  T: Chromosome,
+  M: MutationOperator<T>,
+  C: CrossoverOperator<T>,
+  S: SelectionOperator<T>,
+  P: PopulationGenerator<T>,
+  Pr: Probe<T>,
 {
-	pub fn new() -> Self {
+  pub fn new() -> Self {
     Self {
       params: Some(GAParams::default()),
       fitness_fn: None,
@@ -94,7 +94,7 @@ where
   P: PopulationGenerator<Vec<f64>>,
   Pr: Probe<Vec<f64>>,
 {
-	config: GAConfigOpt<Vec<f64>, M, C, S, P, Pr>
+  config: GAConfigOpt<Vec<f64>, M, C, S, P, Pr>,
 }
 
 impl<M, C, S, P, Pr> RealValuedBuilder<M, C, S, P, Pr>
@@ -275,8 +275,6 @@ where
 #[cfg(test)]
 mod test {
 
-	#[test]
-	fn api_test() {
-	}
+  #[test]
+  fn api_test() {}
 }
-

--- a/src/ga/builder.rs
+++ b/src/ga/builder.rs
@@ -1,4 +1,4 @@
-pub mod realvalued;
+pub mod presets;
 
 use super::individual::Chromosome;
 use super::operators::selection::SelectionOperator;

--- a/src/ga/builder.rs
+++ b/src/ga/builder.rs
@@ -1,7 +1,5 @@
 pub mod presets;
 
-use std::marker::PhantomData;
-
 use super::individual::Chromosome;
 use super::operators::selection::SelectionOperator;
 use super::population::PopulationGenerator;

--- a/src/ga/builder.rs
+++ b/src/ga/builder.rs
@@ -1,9 +1,6 @@
-use std::ops::Index;
-
 use super::individual::Chromosome;
-use super::operators::mutation::Identity;
-use super::operators::selection::SelectionOperator;
-use super::population::PopulationGenerator;
+use super::operators::selection::{SelectionOperator, StochasticUniversalSampling, Boltzmann};
+use super::population::{PopulationGenerator, RandomPoints, BitStrings};
 use super::{
   CrossoverOperator, FitnessFn, GAConfig, GAParams, GeneticAlgorithm, Individual, MutationOperator, Probe,
 };
@@ -48,27 +45,6 @@ where
   }
 }
 
-impl<T, C, S, P, Pr> Default for GAConfigOpt<T, Identity, C, S, P, Pr>
-where
-  T: Chromosome + Index<usize>,
-  C: CrossoverOperator<T>,
-  S: SelectionOperator<T>,
-  P: PopulationGenerator<T>,
-  Pr: Probe<T>,
-{
-  fn default() -> Self {
-    Self {
-      params: Some(GAParams::default()),
-      fitness_fn: None,
-      mutation_operator: Some(Identity::new()),
-      crossover_operator: None,
-      selection_operator: None,
-      population_factory: None,
-      probe: None,
-    }
-  }
-}
-
 impl<T, M, C, S, P, Pr> From<GAConfigOpt<T, M, C, S, P, Pr>> for GAConfig<T, M, C, S, P, Pr>
 where
   T: Chromosome,
@@ -91,6 +67,114 @@ where
   }
 }
 
+// pub struct BuilderDispatcher;
+
+// impl BuilderDispatcher {
+// 	pub fn with_real_valued_chromosome<M, C, S, P, Pr>() -> Builder<Vec<f64>, M, C, S, P, Pr>
+// 	where
+// 		M: MutationOperator<Vec<f64>>,
+// 		C: CrossoverOperator<Vec<f64>>,
+// 		S: SelectionOperator<Vec<f64>>,
+// 		P: PopulationGenerator<Vec<f64>>,
+// 		Pr: Probe<Vec<f64>>,
+// 	{
+// 		Builder::new()
+// 	}
+
+// 	pub fn with_bitstring_chromosome() -> Builder<Vec<bool>, Identity, SinglePoint, StochasticUniversalSampling, BitStrings, EmptyProbe> {
+// 		Builder::new()
+// 	}
+// }
+
+pub struct RealValuedBuilder<M, C, S, P, Pr>
+where
+  M: MutationOperator<Vec<f64>>,
+  C: CrossoverOperator<Vec<f64>>,
+  S: SelectionOperator<Vec<f64>>,
+  P: PopulationGenerator<Vec<f64>>,
+  Pr: Probe<Vec<f64>>,
+{
+	config: GAConfigOpt<Vec<f64>, M, C, S, P, Pr>
+}
+
+impl<M, C, S, P, Pr> RealValuedBuilder<M, C, S, P, Pr>
+where
+  M: MutationOperator<Vec<f64>>,
+  C: CrossoverOperator<Vec<f64>>,
+  S: SelectionOperator<Vec<f64>>,
+  P: PopulationGenerator<Vec<f64>>,
+  Pr: Probe<Vec<f64>>,
+{
+  pub fn set_selection_rate(mut self, selection_rate: f64) -> Self {
+    debug_assert!((0f64..=1f64).contains(&selection_rate));
+    self.config.params = self.config.params.map(|mut params| {
+      params.selection_rate = selection_rate;
+      params
+    });
+    self
+  }
+
+  pub fn set_max_duration(mut self, max_duration: std::time::Duration) -> Self {
+    self.config.params = self.config.params.map(|mut params| {
+      params.max_duration = Some(max_duration);
+      params
+    });
+    self
+  }
+
+  pub fn set_max_generation_count(mut self, max_gen_count: usize) -> Self {
+    debug_assert!(max_gen_count >= 1);
+    self.config.params = self.config.params.map(|mut params| {
+      params.generation_upper_bound = max_gen_count;
+      params
+    });
+    self
+  }
+
+  pub fn set_population_size(mut self, size: usize) -> Self {
+    debug_assert!(size > 0);
+    self.config.params = self.config.params.map(|mut params| {
+      params.population_size = size;
+      params
+    });
+    self
+  }
+
+  pub fn set_fitness_fn(mut self, fitness_fn: FitnessFn<Individual<Vec<f64>>>) -> Self {
+    self.config.fitness_fn = Some(fitness_fn);
+    self
+  }
+
+  pub fn set_mutation_operator(mut self, mutation_op: M) -> Self {
+    self.config.mutation_operator = Some(mutation_op);
+    self
+  }
+
+  pub fn set_crossover_operator(mut self, crossover_op: C) -> Self {
+    self.config.crossover_operator = Some(crossover_op);
+    self
+  }
+
+  pub fn set_selection_operator(mut self, selection_op: S) -> Self {
+    self.config.selection_operator = Some(selection_op);
+    self
+  }
+
+  pub fn set_population_generator(mut self, generator: P) -> Self {
+    self.config.population_factory = Some(generator);
+    self
+  }
+
+  pub fn set_probe(mut self, probe: Pr) -> Self {
+    self.config.probe = Some(probe);
+    self
+  }
+
+  pub fn build(self) -> GeneticAlgorithm<Vec<f64>, M, C, S, P, Pr> {
+    GeneticAlgorithm::new(self.config.into())
+  }
+}
+
 pub struct Builder<T, M, C, S, P, Pr>
 where
   T: Chromosome,
@@ -101,19 +185,6 @@ where
   Pr: Probe<T>,
 {
   config: GAConfigOpt<T, M, C, S, P, Pr>,
-}
-
-impl<T, C, S, P, Pr> Default for Builder<T, Identity, C, S, P, Pr>
-where
-	T: Chromosome + Index<usize>,
-	C: CrossoverOperator<T>,
-	S: SelectionOperator<T>,
-	P: PopulationGenerator<T>,
-	Pr: Probe<T>
-{
-	fn default() -> Self {
-		Self { config: Default::default() }
-	}
 }
 
 impl<T, M, C, S, P, Pr> Builder<T, M, C, S, P, Pr>
@@ -200,3 +271,12 @@ where
     GeneticAlgorithm::new(self.config.into())
   }
 }
+
+#[cfg(test)]
+mod test {
+
+	#[test]
+	fn api_test() {
+	}
+}
+

--- a/src/ga/builder/presets.rs
+++ b/src/ga/builder/presets.rs
@@ -72,13 +72,33 @@ impl RealValuedBuilder
 		self
 	}
 
-	pub fn build(self) -> GeneticAlgorithm<Rvc, Identity, SinglePoint, Tournament, RandomPoints, StdoutProbe> {
+	pub fn build(mut self) -> GeneticAlgorithm<Rvc, Identity, SinglePoint, Tournament, RandomPoints, StdoutProbe> {
 		 if self.config.fitness_fn.is_none() {
 				panic!("Fitness function must be set");
 		 }
 
 		if self.dim.is_none() {
 			panic!("Problem dimension must be set");
+		}
+
+		if self.config.crossover_operator.is_none() {
+			self.config.crossover_operator = Some(SinglePoint::new());
+		}
+
+		if self.config.mutation_operator.is_none() {
+			self.config.mutation_operator = Some(Identity::new());
+		}
+
+		if self.config.selection_operator.is_none() {
+			self.config.selection_operator = Some(Tournament::new(0.2));
+		}
+
+		if self.config.population_factory.is_none() {
+			self.config.population_factory = Some(RandomPoints::new(self.dim.unwrap_or(10)));
+		}
+
+		if self.config.probe.is_none() {
+			self.config.probe = Some(StdoutProbe::new());
 		}
 
 		GeneticAlgorithm::new(self.config.into())
@@ -142,13 +162,29 @@ impl BitStringBuilder {
 		self
 	}
 
-	pub fn build(self) -> GeneticAlgorithm<Bsc, Identity, SinglePoint, Tournament, BitStrings, StdoutProbe> {
-		 if self.config.fitness_fn.is_none() {
-				panic!("Fitness function must be set");
-		 }
+	pub fn build(mut self) -> GeneticAlgorithm<Bsc, Identity, SinglePoint, Tournament, BitStrings, StdoutProbe> {
+		if self.config.fitness_fn.is_none() {
+			panic!("Fitness function must be set");
+		}
 
-		if self.dim.is_none() {
-			panic!("Problem dimension must be set");
+		if self.config.crossover_operator.is_none() {
+			self.config.crossover_operator = Some(SinglePoint::new());
+		}
+
+		if self.config.mutation_operator.is_none() {
+			self.config.mutation_operator = Some(Identity::new());
+		}
+
+		if self.config.selection_operator.is_none() {
+			self.config.selection_operator = Some(Tournament::new(0.2));
+		}
+
+		if self.config.population_factory.is_none() {
+			self.config.population_factory = Some(BitStrings::new(self.dim.unwrap_or(10)));
+		}
+
+		if self.config.probe.is_none() {
+			self.config.probe = Some(StdoutProbe::new());
 		}
 
 		GeneticAlgorithm::new(self.config.into())

--- a/src/ga/builder/presets.rs
+++ b/src/ga/builder/presets.rs
@@ -1,28 +1,33 @@
 use crate::ga::{
   operators::{
-    crossover::{CrossoverOperator, SinglePoint},
-    mutation::{Identity, MutationOperator},
-    selection::{SelectionOperator, Tournament},
+    crossover::SinglePoint,
+    mutation::Identity,
+    selection::Tournament,
   },
-  population::{PopulationGenerator, RandomPoints},
-  GAParams, Probe, StdoutProbe, FitnessFn, Individual, GeneticAlgorithm,
+  population::{RandomPoints, BitStrings},
+  StdoutProbe, FitnessFn, Individual, GeneticAlgorithm,
 };
 
 use super::GAConfigOpt;
 
-type RVC = Vec<f64>;
-type BC = Vec<bool>;
+type Rvc = Vec<f64>;
+type Bsc = Vec<bool>;
 
 pub struct RealValuedBuilder
 {
-  config: GAConfigOpt<RVC, Identity, SinglePoint, Tournament, RandomPoints, StdoutProbe>,
+  config: GAConfigOpt<Rvc, Identity, SinglePoint, Tournament, RandomPoints, StdoutProbe>,
+	dim: Option<usize>,
 }
 
 
 impl RealValuedBuilder
 {
-  pub fn set_selection_rate(mut self, selection_rate: f64) -> Self {
-    debug_assert!((0f64..=1f64).contains(&selection_rate));
+	pub(super) fn new() -> Self {
+		RealValuedBuilder { config: GAConfigOpt::new(), dim: None }
+	}
+
+  pub fn selection_rate(mut self, selection_rate: f64) -> Self {
+    assert!((0f64..=1f64).contains(&selection_rate));
     self.config.params = self.config.params.map(|mut params| {
       params.selection_rate = selection_rate;
       params
@@ -30,7 +35,7 @@ impl RealValuedBuilder
     self
   }
 
-  pub fn set_max_duration(mut self, max_duration: std::time::Duration) -> Self {
+  pub fn max_duration(mut self, max_duration: std::time::Duration) -> Self {
     self.config.params = self.config.params.map(|mut params| {
       params.max_duration = Some(max_duration);
       params
@@ -38,8 +43,8 @@ impl RealValuedBuilder
     self
   }
 
-  pub fn set_max_generation_count(mut self, max_gen_count: usize) -> Self {
-    debug_assert!(max_gen_count >= 1);
+  pub fn max_generations(mut self, max_gen_count: usize) -> Self {
+    assert!(max_gen_count >= 1);
     self.config.params = self.config.params.map(|mut params| {
       params.generation_upper_bound = max_gen_count;
       params
@@ -47,8 +52,8 @@ impl RealValuedBuilder
     self
   }
 
-  pub fn set_population_size(mut self, size: usize) -> Self {
-    debug_assert!(size > 0);
+  pub fn population_size(mut self, size: usize) -> Self {
+    assert!(size > 0);
     self.config.params = self.config.params.map(|mut params| {
       params.population_size = size;
       params
@@ -56,19 +61,96 @@ impl RealValuedBuilder
     self
   }
 
-	pub fn fitness_fn(mut self, fitness_fn: FitnessFn<Individual<RVC>>) -> Self {
+	pub fn dim(mut self, dim: usize) -> Self {
+		assert!(dim > 0, "Dimension of a problem must be > 0");
+		self.dim = Some(dim);
+		self
+	}
+
+	pub fn fitness_fn(mut self, fitness_fn: FitnessFn<Individual<Rvc>>) -> Self {
 		self.config.fitness_fn = Some(fitness_fn);
 		self
 	}
 
-	pub fn build(self) -> GeneticAlgorithm<RVC, Identity, SinglePoint, Tournament, RandomPoints, StdoutProbe> {
-		let Some(fitness_fn) = self.config.fitness_fn else {
-			panic!("Fitness function must be set");
-		};
+	pub fn build(self) -> GeneticAlgorithm<Rvc, Identity, SinglePoint, Tournament, RandomPoints, StdoutProbe> {
+		 if self.config.fitness_fn.is_none() {
+				panic!("Fitness function must be set");
+		 }
+
+		if self.dim.is_none() {
+			panic!("Problem dimension must be set");
+		}
 
 		GeneticAlgorithm::new(self.config.into())
 	}
 }
 
 
-pub struct BitStringBuilder {}
+pub struct BitStringBuilder {
+  config: GAConfigOpt<Bsc, Identity, SinglePoint, Tournament, BitStrings, StdoutProbe>,
+	dim: Option<usize>,
+}
+
+impl BitStringBuilder {
+	pub(super) fn new() -> Self {
+		BitStringBuilder { config: GAConfigOpt::new(), dim: None }
+	}
+
+  pub fn selection_rate(mut self, selection_rate: f64) -> Self {
+    assert!((0f64..=1f64).contains(&selection_rate));
+    self.config.params = self.config.params.map(|mut params| {
+      params.selection_rate = selection_rate;
+      params
+    });
+    self
+  }
+
+  pub fn max_duration(mut self, max_duration: std::time::Duration) -> Self {
+    self.config.params = self.config.params.map(|mut params| {
+      params.max_duration = Some(max_duration);
+      params
+    });
+    self
+  }
+
+  pub fn max_generations(mut self, max_gen_count: usize) -> Self {
+    assert!(max_gen_count >= 1);
+    self.config.params = self.config.params.map(|mut params| {
+      params.generation_upper_bound = max_gen_count;
+      params
+    });
+    self
+  }
+
+  pub fn population_size(mut self, size: usize) -> Self {
+    assert!(size > 0);
+    self.config.params = self.config.params.map(|mut params| {
+      params.population_size = size;
+      params
+    });
+    self
+  }
+
+	pub fn dim(mut self, dim: usize) -> Self {
+		assert!(dim > 0, "Dimension of a problem must be > 0");
+		self.dim = Some(dim);
+		self
+	}
+
+	pub fn fitness_fn(mut self, fitness_fn: FitnessFn<Individual<Bsc>>) -> Self {
+		self.config.fitness_fn = Some(fitness_fn);
+		self
+	}
+
+	pub fn build(self) -> GeneticAlgorithm<Bsc, Identity, SinglePoint, Tournament, BitStrings, StdoutProbe> {
+		 if self.config.fitness_fn.is_none() {
+				panic!("Fitness function must be set");
+		 }
+
+		if self.dim.is_none() {
+			panic!("Problem dimension must be set");
+		}
+
+		GeneticAlgorithm::new(self.config.into())
+	}
+}

--- a/src/ga/builder/presets.rs
+++ b/src/ga/builder/presets.rs
@@ -1,0 +1,74 @@
+use crate::ga::{
+  operators::{
+    crossover::{CrossoverOperator, SinglePoint},
+    mutation::{Identity, MutationOperator},
+    selection::{SelectionOperator, Tournament},
+  },
+  population::{PopulationGenerator, RandomPoints},
+  GAParams, Probe, StdoutProbe, FitnessFn, Individual, GeneticAlgorithm,
+};
+
+use super::GAConfigOpt;
+
+type RVC = Vec<f64>;
+type BC = Vec<bool>;
+
+pub struct RealValuedBuilder
+{
+  config: GAConfigOpt<RVC, Identity, SinglePoint, Tournament, RandomPoints, StdoutProbe>,
+}
+
+
+impl RealValuedBuilder
+{
+  pub fn set_selection_rate(mut self, selection_rate: f64) -> Self {
+    debug_assert!((0f64..=1f64).contains(&selection_rate));
+    self.config.params = self.config.params.map(|mut params| {
+      params.selection_rate = selection_rate;
+      params
+    });
+    self
+  }
+
+  pub fn set_max_duration(mut self, max_duration: std::time::Duration) -> Self {
+    self.config.params = self.config.params.map(|mut params| {
+      params.max_duration = Some(max_duration);
+      params
+    });
+    self
+  }
+
+  pub fn set_max_generation_count(mut self, max_gen_count: usize) -> Self {
+    debug_assert!(max_gen_count >= 1);
+    self.config.params = self.config.params.map(|mut params| {
+      params.generation_upper_bound = max_gen_count;
+      params
+    });
+    self
+  }
+
+  pub fn set_population_size(mut self, size: usize) -> Self {
+    debug_assert!(size > 0);
+    self.config.params = self.config.params.map(|mut params| {
+      params.population_size = size;
+      params
+    });
+    self
+  }
+
+	pub fn fitness_fn(mut self, fitness_fn: FitnessFn<Individual<RVC>>) -> Self {
+		self.config.fitness_fn = Some(fitness_fn);
+		self
+	}
+
+	pub fn build(self) -> GeneticAlgorithm<RVC, Identity, SinglePoint, Tournament, RandomPoints, StdoutProbe> {
+		let Some(fitness_fn) = self.config.fitness_fn else {
+			panic!("Fitness function must be set");
+		};
+
+		GeneticAlgorithm::new(self.config.into())
+	}
+}
+
+
+pub struct BitStringBuilder {}

--- a/src/ga/probe.rs
+++ b/src/ga/probe.rs
@@ -3,6 +3,7 @@ use super::{individual::Chromosome, GAMetadata, Individual};
 pub mod csv_probe;
 pub mod json_probe;
 pub mod stdout_probe;
+pub mod empty;
 
 pub trait Probe<T: Chromosome> {
   fn on_start(&mut self, _metadata: &GAMetadata) { /* defaults to noop */

--- a/src/ga/probe.rs
+++ b/src/ga/probe.rs
@@ -1,9 +1,9 @@
 use super::{individual::Chromosome, GAMetadata, Individual};
 
 pub mod csv_probe;
+pub mod empty;
 pub mod json_probe;
 pub mod stdout_probe;
-pub mod empty;
 
 pub trait Probe<T: Chromosome> {
   fn on_start(&mut self, _metadata: &GAMetadata) { /* defaults to noop */

--- a/src/ga/probe/empty.rs
+++ b/src/ga/probe/empty.rs
@@ -10,6 +10,4 @@ impl EmptyProbe {
   }
 }
 
-impl<T: Chromosome> Probe<T> for EmptyProbe {
-
-}
+impl<T: Chromosome> Probe<T> for EmptyProbe {}

--- a/src/ga/probe/empty.rs
+++ b/src/ga/probe/empty.rs
@@ -1,0 +1,15 @@
+use crate::ga::individual::Chromosome;
+
+use super::Probe;
+
+pub struct EmptyProbe;
+
+impl EmptyProbe {
+  pub fn new() -> Self {
+    EmptyProbe
+  }
+}
+
+impl<T: Chromosome> Probe<T> for EmptyProbe {
+
+}

--- a/src/ga/probe/stdout_probe.rs
+++ b/src/ga/probe/stdout_probe.rs
@@ -44,6 +44,21 @@ impl<T: Chromosome> Probe<T> for StdoutProbe {
     );
   }
 
+	fn on_end(
+			&mut self,
+			metadata: &GAMetadata,
+			_population: &[Individual<T>],
+			best_individual: &Individual<T>,
+		) {
+    info!(
+      "[BEST_IN_GEN] {},{},{:?},{}",
+      metadata.duration.unwrap().as_millis(),
+      metadata.generation.unwrap(),
+      best_individual.chromosome_ref(),
+      best_individual.fitness
+    );
+	}
+
   // fn on_iteration_start(&mut self, iteration: usize) {
   //   // TODO: Take iteration count & maybe some more info here (best so far, etc.)
   //   info!("Start of iteration: {}", iteration);

--- a/src/ga/probe/stdout_probe.rs
+++ b/src/ga/probe/stdout_probe.rs
@@ -51,7 +51,7 @@ impl<T: Chromosome> Probe<T> for StdoutProbe {
 			best_individual: &Individual<T>,
 		) {
     info!(
-      "[BEST_IN_GEN] {},{},{:?},{}",
+      "[END] {},{},{:?},{}",
       metadata.duration.unwrap().as_millis(),
       metadata.generation.unwrap(),
       best_individual.chromosome_ref(),


### PR DESCRIPTION
<!-- If applicable - remeber to add the PR to the EA Rust project (ONLY IF THERE IS NO LINKED ISSUE) -->

## Description

Add better defaults for builder.

Right now this PR is stuck, due to problems with implementation.

Rust lacks few important language mechanisms:

* Trait specialization (same as C++ template spec.) is in early development process:
  * https://github.com/rust-lang/rfcs/blob/master/text/1210-impl-specialization.md
  * https://github.com/rust-lang/rust/issues/31844
* Negative impls are unstable
  * https://github.com/rust-lang/rust/issues/68318
  * https://doc.rust-lang.org/beta/unstable-book/language-features/negative-impls.html

It is an issue, because:

1. We want to provide a blanket implementation over `T: Chromosome` for `Builder` struct. It would be ridiculous to force user to implement custom `Builder`.
2. Different operators require different trait bounds on `Chromosome`, thus defaults for different chromosome types must be different (there is really no common ground).

Due to aforementioned language restrictions it seems impossible to implement defaults depending on incoming chromosome type.

Edit:

There is hope however: Rust's macros - as they are quite powerfull - you can operate directly on AST -- so it seems doable, but some research has to be done first.

Edit 2: 

Defaults rarely make any sense as operators are problem specific. There are really no operators that fit the needs of all problems (or are at least valid). 

It seems to me, that we must force end-user to specify operators alongside fitness function. 

Can we se macros somehow to manage this? 

#### Selected solution

So far we focus mostly on two types of chromosome: 

1. real valued (RVC)
2. bit string (BSC)

Therefore I went with following approach: for each chromosome type I created a dedicated builder for which all parameters *except* operators (outside the fixed type) can be modified. 

There is also a single "dispatcher" - `ecrs::ga::Builder` which has factory methods for other builders.

Following API is now available:

```rust
  ecrs::ga::Builder::with_rvc()
    .fitness_fn(rastrigin::rastrigin_fitness)
    .dim(5)
    .build()
    .run()
```

We should consider separating our API into two categories:

* static
* dynamic

Because most of API shape issues arise from the fact that we went for fully static API. We could also expose `dynamic` API, which is configurable in much easier way. 

## Linked issues

Resolves #128 
Resolves #179 
Resolves #180 