### PR TITLE
feat: allow for implicit constraints on point domain in `RandomPoints`

### DIFF
--- a/example/src/ga.rs
+++ b/example/src/ga.rs
@@ -22,7 +22,7 @@ pub fn ga_example() {
     .set_fitness_fn(rastrigin::rastrigin_fitness)
     .set_crossover_operator(Box::new(ga::operators::crossover::SinglePoint::new()))
     .set_mutation_operator(Box::new(ga::operators::mutation::Identity::new()))
-    .set_population_generator(Box::new(ga::population::RandomPoints::new(
+    .set_population_generator(Box::new(ga::population::RandomPoints::with_constraints(
       3,
       vec![-5.12..5.12, -5.12..5.12, -5.12..5.12],
     )))

--- a/src/ga/population.rs
+++ b/src/ga/population.rs
@@ -42,21 +42,24 @@ impl RandomPoints {
     }
   }
 
-	/// Returns [RandomPoints] population generator with no explicit constraints.
-	/// Points coords will be from range 0.0..1.0.
-	///
-	/// ### Arguments
-	///
-	/// * `dim` - Dimension of the sampling space
-	pub fn new(dim: usize) -> Self {
-		assert!(dim > 0, "Space dimension must be > 0");
-		RandomPoints { dim, constraints: Vec::<(f64, f64)>::with_capacity(0) }
-	}
+  /// Returns [RandomPoints] population generator with no explicit constraints.
+  /// Points coords will be from range 0.0..1.0.
+  ///
+  /// ### Arguments
+  ///
+  /// * `dim` - Dimension of the sampling space
+  pub fn new(dim: usize) -> Self {
+    assert!(dim > 0, "Space dimension must be > 0");
+    RandomPoints {
+      dim,
+      constraints: Vec::<(f64, f64)>::with_capacity(0),
+    }
+  }
 }
 
 impl PopulationGenerator<Vec<f64>> for RandomPoints {
   /// Generates vector of `count` random points from R^(dim) space within passed domain constraints.
-	/// If there were no constraints passed then the points coords are from range 0.0..1.0.
+  /// If there were no constraints passed then the points coords are from range 0.0..1.0.
   ///
   /// ### Arguments
   ///
@@ -68,25 +71,25 @@ impl PopulationGenerator<Vec<f64>> for RandomPoints {
     let mut population: Vec<Individual<Vec<f64>>> = Vec::with_capacity(count);
     let rng = &mut rand::thread_rng();
 
-		// We do not use Option to designate whether there are constraints or not
-		// because using unwrap moves!
-		if self.constraints.is_empty() {
-			for _ in 0..count {
-				let mut point = Vec::<f64>::with_capacity(self.dim);
-				for _ in 0..self.dim {
-					point.push(rng.sample(distribution));
-				}
-				population.push(Individual::from(point));
-			}
-		} else {
-			for _ in 0..count {
-				let mut point: Vec<f64> = Vec::with_capacity(self.dim);
-				for restriction in &self.constraints {
-					point.push(restriction.0 * rng.sample(distribution) + restriction.1);
-				}
-				population.push(Individual::from(point));
-			}
-		}
+    // We do not use Option to designate whether there are constraints or not
+    // because using unwrap moves!
+    if self.constraints.is_empty() {
+      for _ in 0..count {
+        let mut point = Vec::<f64>::with_capacity(self.dim);
+        for _ in 0..self.dim {
+          point.push(rng.sample(distribution));
+        }
+        population.push(Individual::from(point));
+      }
+    } else {
+      for _ in 0..count {
+        let mut point: Vec<f64> = Vec::with_capacity(self.dim);
+        for restriction in &self.constraints {
+          point.push(restriction.0 * rng.sample(distribution) + restriction.1);
+        }
+        population.push(Individual::from(point));
+      }
+    }
     population
   }
 }
@@ -165,20 +168,20 @@ mod tests {
     }
   }
 
-	#[test]
-	fn points_follow_implicit_constraints() {
-		let dim = 30;
-		let count = 100;
+  #[test]
+  fn points_follow_implicit_constraints() {
+    let dim = 30;
+    let count = 100;
 
-		let gen = RandomPoints::new(dim);
-		let points: Vec<crate::ga::Individual<Vec<f64>>> = gen.generate(count);
+    let gen = RandomPoints::new(dim);
+    let points: Vec<crate::ga::Individual<Vec<f64>>> = gen.generate(count);
 
-		for p in points {
-			for v in p.chromosome_ref() {
-				assert!((0.0..1.0).contains(v));
-			}
-		}
-	}
+    for p in points {
+      for v in p.chromosome_ref() {
+        assert!((0.0..1.0).contains(v));
+      }
+    }
+  }
 
   #[test]
   fn bistrings_have_appropriate_len() {

--- a/src/ga/population.rs
+++ b/src/ga/population.rs
@@ -12,39 +12,51 @@ pub trait PopulationGenerator<T: Chromosome> {
 
 /// Implements [PopulationGenerator] trait. Can be used with genetic algorithm.
 ///
-/// Generates vector of random points from R^(dim) space within passed domain restrictions.
+/// Generates vector of random points from R^(dim) space within passed domain constraints.
 pub struct RandomPoints {
   dim: usize,
-  restrictions: Vec<(f64, f64)>,
+  constraints: Vec<(f64, f64)>,
 }
 
 impl RandomPoints {
-  /// Returns [RandomPoints] population generator
+  /// Returns [RandomPoints] population generator with given constraints
   ///
   /// ### Arguments
   ///
   /// * `dim` -- Dimension of the sampling space
-  /// * `restrictions` -- Ranges for coordinates
-  pub fn new(dim: usize, restrictions: Vec<Range<f64>>) -> Self {
+  /// * `constraints` -- Ranges for coordinates
+  pub fn with_constraints(dim: usize, constraints: Vec<Range<f64>>) -> Self {
     assert!(dim > 0, "Space dimension must be > 0");
     assert_eq!(
       dim,
-      restrictions.len(),
-      "Number of restrictions must match dimension of sampled space"
+      constraints.len(),
+      "Number of constraints must match dimension of sampled space"
     );
 
     RandomPoints {
       dim,
-      restrictions: restrictions
+      constraints: constraints
         .into_iter()
         .map(|range| (range.end - range.start, range.start))
         .collect_vec(),
     }
   }
+
+	/// Returns [RandomPoints] population generator with no explicit constraints.
+	/// Points coords will be from range 0.0..1.0.
+	///
+	/// ### Arguments
+	///
+	/// * `dim` - Dimension of the sampling space
+	pub fn new(dim: usize) -> Self {
+		assert!(dim > 0, "Space dimension must be > 0");
+		RandomPoints { dim, constraints: Vec::<(f64, f64)>::with_capacity(0) }
+	}
 }
 
 impl PopulationGenerator<Vec<f64>> for RandomPoints {
-  /// Generates vector of `count` random points from R^(dim) space within passed domain restrictions
+  /// Generates vector of `count` random points from R^(dim) space within passed domain constraints.
+	/// If there were no constraints passed then the points coords are from range 0.0..1.0.
   ///
   /// ### Arguments
   ///
@@ -56,14 +68,25 @@ impl PopulationGenerator<Vec<f64>> for RandomPoints {
     let mut population: Vec<Individual<Vec<f64>>> = Vec::with_capacity(count);
     let rng = &mut rand::thread_rng();
 
-    for _ in 0..count {
-      let mut point: Vec<f64> = Vec::with_capacity(self.dim);
-      for restriction in &self.restrictions {
-        point.push(restriction.0 * rng.sample(distribution) + restriction.1);
-      }
-      population.push(Individual::from(point));
-    }
-
+		// We do not use Option to designate whether there are constraints or not
+		// because using unwrap moves!
+		if self.constraints.is_empty() {
+			for _ in 0..count {
+				let mut point = Vec::<f64>::with_capacity(self.dim);
+				for _ in 0..self.dim {
+					point.push(rng.sample(distribution));
+				}
+				population.push(Individual::from(point));
+			}
+		} else {
+			for _ in 0..count {
+				let mut point: Vec<f64> = Vec::with_capacity(self.dim);
+				for restriction in &self.constraints {
+					point.push(restriction.0 * rng.sample(distribution) + restriction.1);
+				}
+				population.push(Individual::from(point));
+			}
+		}
     population
   }
 }
@@ -120,7 +143,7 @@ mod tests {
   #[test]
   fn points_have_appropriate_len() {
     let dim = 4;
-    let gen = RandomPoints::new(dim, vec![(0.0..2.0), (-1.0..1.0), (3.0..10.0), (-5.0..-4.0)]);
+    let gen = RandomPoints::with_constraints(dim, vec![(0.0..2.0), (-1.0..1.0), (3.0..10.0), (-5.0..-4.0)]);
     let points: Vec<crate::ga::Individual<Vec<f64>>> = gen.generate(30);
 
     for p in points {
@@ -129,18 +152,33 @@ mod tests {
   }
 
   #[test]
-  fn points_follow_restrictions() {
+  fn points_follow_explicit_constraints() {
     let dim = 4;
-    let restrictions = vec![(0.0..2.0), (-1.0..1.0), (3.0..10.0), (-5.0..-4.0)];
-    let gen = RandomPoints::new(dim, restrictions.clone());
+    let constraints = vec![(0.0..2.0), (-1.0..1.0), (3.0..10.0), (-5.0..-4.0)];
+    let gen = RandomPoints::with_constraints(dim, constraints.clone());
     let points: Vec<crate::ga::Individual<Vec<f64>>> = gen.generate(30);
 
     for p in points {
-      for (v, res) in std::iter::zip(p.chromosome_ref(), &restrictions) {
-        assert!(res.contains(v))
+      for (v, res) in std::iter::zip(p.chromosome_ref(), &constraints) {
+        assert!(res.contains(v));
       }
     }
   }
+
+	#[test]
+	fn points_follow_implicit_constraints() {
+		let dim = 30;
+		let count = 100;
+
+		let gen = RandomPoints::new(dim);
+		let points: Vec<crate::ga::Individual<Vec<f64>>> = gen.generate(count);
+
+		for p in points {
+			for v in p.chromosome_ref() {
+				assert!((0.0..1.0).contains(v));
+			}
+		}
+	}
 
   #[test]
   fn bistrings_have_appropriate_len() {

--- a/tests/selection_tests.rs
+++ b/tests/selection_tests.rs
@@ -172,7 +172,7 @@ fn boltzmann_returns_demanded_size() {
     constraints.push(-1.0..1.0);
   }
 
-  let population = RandomPoints::new(dim, constraints).generate(expected_population_size);
+  let population = RandomPoints::with_constraints(dim, constraints).generate(expected_population_size);
 
   assert_eq!(
     expected_population_size,


### PR DESCRIPTION
<!-- If applicable - remeber to add the PR to the EA Rust project (ONLY IF THERE IS NO LINKED ISSUE) -->

## Description

Allow for implicit constraints on point domain in `RandomPoints` population generator.


## Important implementation details


I decided to detect whether there are constraints or not by checking whether constraints vector is empty. I did not use `Option` because using `.unwrap()` consumes `self` & it lead to inconveniences.  
