### PR TITLE
feat: add probing policy

### DIFF
--- a/example/src/ga.rs
+++ b/example/src/ga.rs
@@ -18,7 +18,7 @@ pub fn point_generator(restrictions: &Vec<(f64, f64)>) -> Vec<f64> {
 
 pub fn ga_example() {
   let res = ecrs::ga::Builder::new()
-    .set_max_generation_count(500)
+    .set_max_generation_count(50_000)
     .set_population_size(100)
     .set_fitness_fn(rastrigin::rastrigin_fitness)
     .set_crossover_operator(ga::operators::crossover::SinglePoint::new())
@@ -29,7 +29,7 @@ pub fn ga_example() {
     ))
     .set_selection_operator(ga::operators::selection::Boltzmann::new(0.05, 80.0, 500, false))
     .set_probe(ga::probe::PolicyDrivenProbe::new(
-      ga::probe::GenerationInterval::new(30, 1),
+      ga::probe::ElapsedTime::new(std::time::Duration::from_millis(300), std::time::Duration::ZERO),
       ga::probe::StdoutProbe,
     ))
     .build()

--- a/example/src/ga.rs
+++ b/example/src/ga.rs
@@ -28,10 +28,17 @@ pub fn ga_example() {
       vec![-5.12..5.12, -5.12..5.12, -5.12..5.12],
     ))
     .set_selection_operator(ga::operators::selection::Boltzmann::new(0.05, 80.0, 500, false))
-    .set_probe(ga::probe::PolicyDrivenProbe::new(
-      ga::probe::ElapsedTime::new(std::time::Duration::from_millis(300), std::time::Duration::ZERO),
-      ga::probe::StdoutProbe,
-    ))
+    .set_probe(
+      ga::probe::AggregatedProbe::new()
+        .add_probe(ga::probe::PolicyDrivenProbe::new(
+          ga::probe::ElapsedTime::new(std::time::Duration::from_millis(200), std::time::Duration::ZERO),
+          ga::probe::StdoutProbe,
+        ))
+        .add_probe(ga::probe::PolicyDrivenProbe::new(
+          ga::probe::GenerationInterval::new(500, 100),
+          ga::probe::StdoutProbe,
+        )),
+    )
     .build()
     .run();
 

--- a/example/src/ga.rs
+++ b/example/src/ga.rs
@@ -28,7 +28,10 @@ pub fn ga_example() {
       vec![-5.12..5.12, -5.12..5.12, -5.12..5.12],
     ))
     .set_selection_operator(ga::operators::selection::Boltzmann::new(0.05, 80.0, 500, false))
-    .set_probe(ga::probe::stdout_probe::StdoutProbe)
+    .set_probe(ga::probe::PolicyDrivenProbe::new(
+      ga::probe::GenerationInterval::new(30, 1),
+      ga::probe::StdoutProbe,
+    ))
     .build()
     .run();
 

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -41,7 +41,7 @@ fn main() {
   };
 
   ga::ga_example();
-  ga::ga_rvc_example();
-  ga::ga_bsc_example();
-  ga::ga_exmaple_test_functions();
+  // ga::ga_rvc_example();
+  // ga::ga_bsc_example();
+  // ga::ga_exmaple_test_functions();
 }

--- a/src/ga.rs
+++ b/src/ga.rs
@@ -6,9 +6,9 @@ pub mod probe;
 
 pub use builder::*;
 pub use individual::Individual;
-pub use probe::csv_probe::CsvProbe;
-pub use probe::json_probe::JsonProbe;
-pub use probe::stdout_probe::StdoutProbe;
+pub use probe::CsvProbe;
+pub use probe::JsonProbe;
+pub use probe::StdoutProbe;
 pub use probe::Probe;
 
 use self::{

--- a/src/ga.rs
+++ b/src/ga.rs
@@ -62,14 +62,14 @@ where
 pub struct GAMetadata {
   start_time: Option<std::time::Instant>,
   duration: Option<std::time::Duration>,
-  generation: Option<usize>,
+  generation: usize,
 }
 
 impl GAMetadata {
   pub fn new(
     start_time: Option<std::time::Instant>,
     duration: Option<std::time::Duration>,
-    generation: Option<usize>,
+    generation: usize,
   ) -> Self {
     GAMetadata {
       start_time,
@@ -104,7 +104,7 @@ where
   pub fn new(config: GAConfig<T, M, C, S, P, Pr>) -> Self {
     GeneticAlgorithm {
       config,
-      metadata: GAMetadata::new(None, None, None),
+      metadata: GAMetadata::new(None, None, 0),
     }
   }
 
@@ -146,10 +146,10 @@ where
     // self.config.probe.on_new_best(&self.metadata, best_individual);
 
     for generation_no in 1..=self.config.params.generation_limit {
-      self.metadata.generation = Some(generation_no);
+      self.metadata.generation = generation_no;
       self.metadata.duration = Some(self.metadata.start_time.unwrap().elapsed());
 
-      self.config.probe.on_iteration_start(generation_no);
+      self.config.probe.on_iteration_start(&self.metadata);
 
       // 2. Evaluate fitness for each individual.
       self.evaluate_fitness_in_population(&mut population);
@@ -206,7 +206,7 @@ where
           .on_new_best(&self.metadata, &best_individual_all_time);
       }
 
-      self.config.probe.on_iteration_end(generation_no);
+      self.config.probe.on_iteration_end(&self.metadata);
 
       if self.metadata.start_time.unwrap().elapsed() >= self.config.params.max_duration {
         break;

--- a/src/ga.rs
+++ b/src/ga.rs
@@ -149,6 +149,8 @@ where
       self.metadata.generation = Some(generation_no);
       self.metadata.duration = Some(self.metadata.start_time.unwrap().elapsed());
 
+      self.config.probe.on_iteration_start(generation_no);
+
       // 2. Evaluate fitness for each individual.
       self.evaluate_fitness_in_population(&mut population);
 
@@ -203,6 +205,8 @@ where
           .probe
           .on_new_best(&self.metadata, &best_individual_all_time);
       }
+
+      self.config.probe.on_iteration_end(generation_no);
 
       if self.metadata.start_time.unwrap().elapsed() >= self.config.params.max_duration {
         break;

--- a/src/ga.rs
+++ b/src/ga.rs
@@ -8,8 +8,8 @@ pub use builder::*;
 pub use individual::Individual;
 pub use probe::CsvProbe;
 pub use probe::JsonProbe;
-pub use probe::StdoutProbe;
 pub use probe::Probe;
+pub use probe::StdoutProbe;
 
 use self::{
   individual::Chromosome,

--- a/src/ga/builder/bistring.rs
+++ b/src/ga/builder/bistring.rs
@@ -1,7 +1,8 @@
 use crate::ga::{
   operators::{crossover::SinglePoint, mutation::FlipBit, selection::Tournament},
   population::BitStrings,
-  FitnessFn, GeneticAlgorithm, probe::StdoutProbe,
+  probe::StdoutProbe,
+  FitnessFn, GeneticAlgorithm,
 };
 
 use super::{DefaultParams, GAConfigOpt};

--- a/src/ga/builder/bistring.rs
+++ b/src/ga/builder/bistring.rs
@@ -1,7 +1,7 @@
 use crate::ga::{
   operators::{crossover::SinglePoint, mutation::FlipBit, selection::Tournament},
   population::BitStrings,
-  FitnessFn, GeneticAlgorithm, StdoutProbe,
+  FitnessFn, GeneticAlgorithm, probe::StdoutProbe,
 };
 
 use super::{DefaultParams, GAConfigOpt};

--- a/src/ga/builder/realvalued.rs
+++ b/src/ga/builder/realvalued.rs
@@ -1,7 +1,7 @@
 use crate::ga::{
   operators::{crossover::SinglePoint, mutation::Interchange, selection::Tournament},
   population::RandomPoints,
-  FitnessFn, GeneticAlgorithm, StdoutProbe,
+  FitnessFn, GeneticAlgorithm, probe::StdoutProbe,
 };
 
 use super::{DefaultParams, GAConfigOpt};

--- a/src/ga/builder/realvalued.rs
+++ b/src/ga/builder/realvalued.rs
@@ -1,7 +1,8 @@
 use crate::ga::{
   operators::{crossover::SinglePoint, mutation::Interchange, selection::Tournament},
   population::RandomPoints,
-  FitnessFn, GeneticAlgorithm, probe::StdoutProbe,
+  probe::StdoutProbe,
+  FitnessFn, GeneticAlgorithm,
 };
 
 use super::{DefaultParams, GAConfigOpt};

--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -489,7 +489,7 @@ where
     let mut selected: Vec<&Individual<T>> = Vec::with_capacity(count);
     let mut weights: Vec<f64> = Vec::with_capacity(count);
 
-    let k = 1.0 + 100.0 * (metadata.generation.unwrap() as f64) / (self.max_gen_count as f64);
+    let k = 1.0 + 100.0 * (metadata.generation as f64) / (self.max_gen_count as f64);
     let temp = self.temp_0 * (1.0 - self.alpha).powf(k);
 
     for idv in population {

--- a/src/ga/probe.rs
+++ b/src/ga/probe.rs
@@ -28,9 +28,9 @@ pub trait Probe<T: Chromosome> {
   fn on_best_fit_in_generation(&mut self, _metadata: &GAMetadata, _individual: &Individual<T>) {
     /* defaults to noop */
   }
-  fn on_iteration_start(&mut self, _iteration: usize) { /* defaults to noop */
+  fn on_iteration_start(&mut self, _metadata: &GAMetadata) { /* defaults to noop */
   }
-  fn on_iteration_end(&mut self, _iteration: usize) { /* defaults to noop */
+  fn on_iteration_end(&mut self, _metadata: &GAMetadata) { /* defaults to noop */
   }
   fn on_end(
     &mut self,
@@ -47,8 +47,8 @@ pub trait ProbingPolicy<T: Chromosome> {
   fn on_new_best(&mut self, _metadata: &GAMetadata, _individual: &Individual<T>) -> bool;
   fn on_new_generation(&mut self, _generation: &[Individual<T>]) -> bool;
   fn on_best_fit_in_generation(&mut self, _metadata: &GAMetadata, _individual: &Individual<T>) -> bool;
-  fn on_iteration_start(&mut self, _iteration: usize) -> bool;
-  fn on_iteration_end(&mut self, _iteration: usize) -> bool;
+  fn on_iteration_start(&mut self, _metadata: &GAMetadata) -> bool;
+  fn on_iteration_end(&mut self, _metadata: &GAMetadata) -> bool;
   fn on_end(
     &mut self,
     _metadata: &GAMetadata,

--- a/src/ga/probe.rs
+++ b/src/ga/probe.rs
@@ -11,7 +11,7 @@ pub use csv_probe::CsvProbe;
 pub use empty::EmptyProbe;
 pub use json_probe::JsonProbe;
 pub use policy_driven_probe::PolicyDrivenProbe;
-pub use probing_policy::GenerationInterval;
+pub use probing_policy::{GenerationInterval, ElapsedTime};
 pub use stdout_probe::StdoutProbe;
 
 pub trait Probe<T: Chromosome> {

--- a/src/ga/probe.rs
+++ b/src/ga/probe.rs
@@ -5,6 +5,7 @@ pub mod empty;
 pub mod json_probe;
 pub mod probing_policy;
 pub mod stdout_probe;
+pub mod policy_driven_probe;
 
 pub trait Probe<T: Chromosome> {
   fn on_start(&mut self, _metadata: &GAMetadata) { /* defaults to noop */

--- a/src/ga/probe.rs
+++ b/src/ga/probe.rs
@@ -1,5 +1,6 @@
 use super::{individual::Chromosome, GAMetadata, Individual};
 
+mod aggregated_probe;
 mod csv_probe;
 mod empty;
 mod json_probe;
@@ -7,6 +8,7 @@ mod policy_driven_probe;
 mod probing_policy;
 mod stdout_probe;
 
+pub use aggregated_probe::AggregatedProbe;
 pub use csv_probe::CsvProbe;
 pub use empty::EmptyProbe;
 pub use json_probe::JsonProbe;

--- a/src/ga/probe.rs
+++ b/src/ga/probe.rs
@@ -3,6 +3,7 @@ use super::{individual::Chromosome, GAMetadata, Individual};
 pub mod csv_probe;
 pub mod empty;
 pub mod json_probe;
+pub mod probing_policy;
 pub mod stdout_probe;
 
 pub trait Probe<T: Chromosome> {
@@ -30,4 +31,20 @@ pub trait Probe<T: Chromosome> {
     _best_individual: &Individual<T>,
   ) { /* defaults to noop */
   }
+}
+
+pub trait ProbingPolicy<T: Chromosome> {
+  fn on_start(&mut self, _metadata: &GAMetadata) -> bool;
+  fn on_initial_population_created(&mut self, _population: &[Individual<T>]) -> bool;
+  fn on_new_best(&mut self, _metadata: &GAMetadata, _individual: &Individual<T>) -> bool;
+  fn on_new_generation(&mut self, _generation: &[Individual<T>]) -> bool;
+  fn on_best_fit_in_generation(&mut self, _metadata: &GAMetadata, _individual: &Individual<T>) -> bool;
+  fn on_iteration_start(&mut self, _iteration: usize) -> bool;
+  fn on_iteration_end(&mut self, _iteration: usize) -> bool;
+  fn on_end(
+    &mut self,
+    _metadata: &GAMetadata,
+    _population: &[Individual<T>],
+    _best_individual: &Individual<T>,
+  ) -> bool;
 }

--- a/src/ga/probe.rs
+++ b/src/ga/probe.rs
@@ -11,7 +11,7 @@ pub use csv_probe::CsvProbe;
 pub use empty::EmptyProbe;
 pub use json_probe::JsonProbe;
 pub use policy_driven_probe::PolicyDrivenProbe;
-pub use probing_policy::{GenerationInterval, ElapsedTime};
+pub use probing_policy::{ElapsedTime, GenerationInterval};
 pub use stdout_probe::StdoutProbe;
 
 pub trait Probe<T: Chromosome> {

--- a/src/ga/probe.rs
+++ b/src/ga/probe.rs
@@ -1,11 +1,18 @@
 use super::{individual::Chromosome, GAMetadata, Individual};
 
-pub mod csv_probe;
-pub mod empty;
-pub mod json_probe;
-pub mod probing_policy;
-pub mod stdout_probe;
-pub mod policy_driven_probe;
+mod csv_probe;
+mod empty;
+mod json_probe;
+mod policy_driven_probe;
+mod probing_policy;
+mod stdout_probe;
+
+pub use csv_probe::CsvProbe;
+pub use empty::EmptyProbe;
+pub use json_probe::JsonProbe;
+pub use policy_driven_probe::PolicyDrivenProbe;
+pub use probing_policy::GenerationInterval;
+pub use stdout_probe::StdoutProbe;
 
 pub trait Probe<T: Chromosome> {
   fn on_start(&mut self, _metadata: &GAMetadata) { /* defaults to noop */

--- a/src/ga/probe/aggregated_probe.rs
+++ b/src/ga/probe/aggregated_probe.rs
@@ -1,0 +1,71 @@
+use super::Probe;
+use crate::ga::{individual::Chromosome, GAMetadata, Individual};
+
+pub struct AggregatedProbe<T: Chromosome> {
+  probes: Vec<Box<dyn Probe<T>>>,
+}
+
+impl<T: Chromosome> AggregatedProbe<T> {
+  pub fn new() -> Self {
+    Self { probes: Vec::new() }
+  }
+
+  pub fn add_probe<Pr: Probe<T> + 'static>(mut self, probe: Pr) -> Self {
+    self.probes.push(Box::new(probe));
+    self
+  }
+}
+
+impl<T: Chromosome> Probe<T> for AggregatedProbe<T> {
+  fn on_start(&mut self, metadata: &GAMetadata) {
+    /* defaults to noop */
+    for probe in &mut self.probes {
+      probe.on_start(metadata);
+    }
+  }
+
+  fn on_initial_population_created(&mut self, population: &[Individual<T>]) {
+    for probe in &mut self.probes {
+      probe.on_initial_population_created(population);
+    }
+  }
+
+  fn on_new_best(&mut self, metadata: &GAMetadata, individual: &Individual<T>) {
+    for probe in &mut self.probes {
+      probe.on_new_best(metadata, individual);
+    }
+  }
+
+  fn on_new_generation(&mut self, generation: &[Individual<T>]) {
+    /* defaults to noop */
+    for probe in &mut self.probes {
+      probe.on_new_generation(generation);
+    }
+  }
+
+  fn on_best_fit_in_generation(&mut self, metadata: &GAMetadata, individual: &Individual<T>) {
+    for probe in &mut self.probes {
+      probe.on_best_fit_in_generation(metadata, individual);
+    }
+  }
+
+  fn on_iteration_start(&mut self, metadata: &GAMetadata) {
+    /* defaults to noop */
+    for probe in &mut self.probes {
+      probe.on_iteration_start(metadata);
+    }
+  }
+
+  fn on_iteration_end(&mut self, metadata: &GAMetadata) {
+    /* defaults to noop */
+    for probe in &mut self.probes {
+      probe.on_iteration_end(metadata);
+    }
+  }
+
+  fn on_end(&mut self, metadata: &GAMetadata, population: &[Individual<T>], best_individual: &Individual<T>) {
+    for probe in &mut self.probes {
+      probe.on_end(metadata, population, best_individual);
+    }
+  }
+}

--- a/src/ga/probe/policy_driven_probe.rs
+++ b/src/ga/probe/policy_driven_probe.rs
@@ -62,17 +62,16 @@ impl<T: Chromosome, Pc: ProbingPolicy<T>, Pr: Probe<T>> Probe<T> for PolicyDrive
     }
   }
 
-  fn on_iteration_start(&mut self, iteration: usize) {
+  fn on_iteration_start(&mut self, metadata: &GAMetadata) {
     /* defaults to noop */
-    if self.policy.on_iteration_start(iteration) {
-      self.probe.on_iteration_start(iteration);
+    if self.policy.on_iteration_start(metadata) {
+      self.probe.on_iteration_start(metadata);
     }
   }
 
-  fn on_iteration_end(&mut self, iteration: usize) {
-    /* defaults to noop */
-    if self.policy.on_iteration_end(iteration) {
-      self.probe.on_iteration_end(iteration);
+  fn on_iteration_end(&mut self, metadata: &GAMetadata) {
+    if self.policy.on_iteration_end(metadata) {
+      self.probe.on_iteration_end(metadata);
     }
   }
 

--- a/src/ga/probe/policy_driven_probe.rs
+++ b/src/ga/probe/policy_driven_probe.rs
@@ -1,0 +1,85 @@
+use std::marker::PhantomData;
+
+use crate::ga::{individual::Chromosome, GAMetadata, Individual};
+
+use super::{Probe, ProbingPolicy};
+
+/// ## PolicyDrivenProbe
+///
+/// Checks whether policy allows for logging and if so, delegates actual logging to wrapped probe
+pub struct PolicyDrivenProbe<T: Chromosome, Pc: ProbingPolicy<T>, Pr: Probe<T>> {
+	policy: Pc,
+	probe: Pr,
+	_phantom: PhantomData<T>, // FIXME: Is there a way to avoid it?
+}
+
+impl<T: Chromosome, Pc: ProbingPolicy<T>, Pr: Probe<T>> PolicyDrivenProbe<T, Pc, Pr> {
+	/// Returns new instance of [PolicyDrivenProbe]
+	///
+	/// ### Arguments
+	///
+	/// * `policy` - logging policy to apply
+	/// * `probe` - probe used to logging
+	pub fn new(policy: Pc, probe: Pr) -> Self {
+		Self {
+			policy,
+			probe,
+			_phantom: PhantomData,
+		}
+	}
+}
+
+impl<T: Chromosome, Pc: ProbingPolicy<T>, Pr: Probe<T>> Probe<T> for PolicyDrivenProbe<T, Pc, Pr> {
+  fn on_start(&mut self, metadata: &GAMetadata) { /* defaults to noop */
+		if self.policy.on_start(metadata) {
+			self.probe.on_start(metadata);
+		}
+  }
+
+  fn on_initial_population_created(&mut self, population: &[Individual<T>]) {
+		if self.policy.on_initial_population_created(population) {
+			self.probe.on_initial_population_created(population);
+		}
+  }
+
+  fn on_new_best(&mut self, metadata: &GAMetadata, individual: &Individual<T>) {
+		if self.policy.on_new_best(metadata, individual) {
+			self.probe.on_new_best(metadata, individual);
+		}
+  }
+
+  fn on_new_generation(&mut self, generation: &[Individual<T>]) { /* defaults to noop */
+	 if self.policy.on_new_generation(generation) {
+			self.probe.on_new_generation(generation);
+	 }
+  }
+
+  fn on_best_fit_in_generation(&mut self, metadata: &GAMetadata, individual: &Individual<T>) {
+		if self.policy.on_best_fit_in_generation(metadata, individual) {
+			self.probe.on_best_fit_in_generation(metadata, individual);
+		}
+  }
+
+  fn on_iteration_start(&mut self, iteration: usize) { /* defaults to noop */
+		if self.policy.on_iteration_start(iteration) {
+			self.probe.on_iteration_start(iteration);
+		}
+  }
+
+  fn on_iteration_end(&mut self, iteration: usize) { /* defaults to noop */
+		if self.policy.on_iteration_end(iteration) {
+			self.probe.on_iteration_end(iteration);
+		}
+  }
+
+  fn on_end(
+    &mut self,
+    metadata: &GAMetadata,
+    population: &[Individual<T>],
+    best_individual: &Individual<T>)
+	{
+		if self.policy.on_end(metadata, population, best_individual) {
+			self.probe.on_end(metadata, population, best_individual);
+		}
+  }
+}

--- a/src/ga/probe/policy_driven_probe.rs
+++ b/src/ga/probe/policy_driven_probe.rs
@@ -8,78 +8,77 @@ use super::{Probe, ProbingPolicy};
 ///
 /// Checks whether policy allows for logging and if so, delegates actual logging to wrapped probe
 pub struct PolicyDrivenProbe<T: Chromosome, Pc: ProbingPolicy<T>, Pr: Probe<T>> {
-	policy: Pc,
-	probe: Pr,
-	_phantom: PhantomData<T>, // FIXME: Is there a way to avoid it?
+  policy: Pc,
+  probe: Pr,
+  _phantom: PhantomData<T>, // FIXME: Is there a way to avoid it?
 }
 
 impl<T: Chromosome, Pc: ProbingPolicy<T>, Pr: Probe<T>> PolicyDrivenProbe<T, Pc, Pr> {
-	/// Returns new instance of [PolicyDrivenProbe]
-	///
-	/// ### Arguments
-	///
-	/// * `policy` - logging policy to apply
-	/// * `probe` - probe used to logging
-	pub fn new(policy: Pc, probe: Pr) -> Self {
-		Self {
-			policy,
-			probe,
-			_phantom: PhantomData,
-		}
-	}
+  /// Returns new instance of [PolicyDrivenProbe]
+  ///
+  /// ### Arguments
+  ///
+  /// * `policy` - logging policy to apply
+  /// * `probe` - probe used to logging
+  pub fn new(policy: Pc, probe: Pr) -> Self {
+    Self {
+      policy,
+      probe,
+      _phantom: PhantomData,
+    }
+  }
 }
 
 impl<T: Chromosome, Pc: ProbingPolicy<T>, Pr: Probe<T>> Probe<T> for PolicyDrivenProbe<T, Pc, Pr> {
-  fn on_start(&mut self, metadata: &GAMetadata) { /* defaults to noop */
-		if self.policy.on_start(metadata) {
-			self.probe.on_start(metadata);
-		}
+  fn on_start(&mut self, metadata: &GAMetadata) {
+    /* defaults to noop */
+    if self.policy.on_start(metadata) {
+      self.probe.on_start(metadata);
+    }
   }
 
   fn on_initial_population_created(&mut self, population: &[Individual<T>]) {
-		if self.policy.on_initial_population_created(population) {
-			self.probe.on_initial_population_created(population);
-		}
+    if self.policy.on_initial_population_created(population) {
+      self.probe.on_initial_population_created(population);
+    }
   }
 
   fn on_new_best(&mut self, metadata: &GAMetadata, individual: &Individual<T>) {
-		if self.policy.on_new_best(metadata, individual) {
-			self.probe.on_new_best(metadata, individual);
-		}
+    if self.policy.on_new_best(metadata, individual) {
+      self.probe.on_new_best(metadata, individual);
+    }
   }
 
-  fn on_new_generation(&mut self, generation: &[Individual<T>]) { /* defaults to noop */
-	 if self.policy.on_new_generation(generation) {
-			self.probe.on_new_generation(generation);
-	 }
+  fn on_new_generation(&mut self, generation: &[Individual<T>]) {
+    /* defaults to noop */
+    if self.policy.on_new_generation(generation) {
+      self.probe.on_new_generation(generation);
+    }
   }
 
   fn on_best_fit_in_generation(&mut self, metadata: &GAMetadata, individual: &Individual<T>) {
-		if self.policy.on_best_fit_in_generation(metadata, individual) {
-			self.probe.on_best_fit_in_generation(metadata, individual);
-		}
+    if self.policy.on_best_fit_in_generation(metadata, individual) {
+      self.probe.on_best_fit_in_generation(metadata, individual);
+    }
   }
 
-  fn on_iteration_start(&mut self, iteration: usize) { /* defaults to noop */
-		if self.policy.on_iteration_start(iteration) {
-			self.probe.on_iteration_start(iteration);
-		}
+  fn on_iteration_start(&mut self, iteration: usize) {
+    /* defaults to noop */
+    if self.policy.on_iteration_start(iteration) {
+      self.probe.on_iteration_start(iteration);
+    }
   }
 
-  fn on_iteration_end(&mut self, iteration: usize) { /* defaults to noop */
-		if self.policy.on_iteration_end(iteration) {
-			self.probe.on_iteration_end(iteration);
-		}
+  fn on_iteration_end(&mut self, iteration: usize) {
+    /* defaults to noop */
+    if self.policy.on_iteration_end(iteration) {
+      self.probe.on_iteration_end(iteration);
+    }
   }
 
-  fn on_end(
-    &mut self,
-    metadata: &GAMetadata,
-    population: &[Individual<T>],
-    best_individual: &Individual<T>)
-	{
-		if self.policy.on_end(metadata, population, best_individual) {
-			self.probe.on_end(metadata, population, best_individual);
-		}
+  fn on_end(&mut self, metadata: &GAMetadata, population: &[Individual<T>], best_individual: &Individual<T>) {
+    if self.policy.on_end(metadata, population, best_individual) {
+      self.probe.on_end(metadata, population, best_individual);
+    }
   }
 }

--- a/src/ga/probe/probing_policy.rs
+++ b/src/ga/probe/probing_policy.rs
@@ -1,4 +1,6 @@
-use crate::ga::individual::Chromosome;
+use std::time::Duration;
+
+use crate::ga::{individual::Chromosome, GAMetadata};
 
 use super::ProbingPolicy;
 
@@ -59,8 +61,8 @@ impl<T: Chromosome> ProbingPolicy<T> for GenerationInterval {
   }
 
   #[inline]
-  fn on_iteration_start(&mut self, iteration: usize) -> bool {
-    if iteration >= self.threshold {
+  fn on_iteration_start(&mut self, metadata: &GAMetadata) -> bool {
+    if metadata.generation >= self.threshold {
       self.threshold += self.interval;
       self.should_log = true;
       true
@@ -70,7 +72,91 @@ impl<T: Chromosome> ProbingPolicy<T> for GenerationInterval {
   }
 
   #[inline(always)]
-  fn on_iteration_end(&mut self, _iteration: usize) -> bool {
+  fn on_iteration_end(&mut self, _metadata: &GAMetadata) -> bool {
+    let prev = self.should_log;
+    self.should_log = false;
+    prev
+  }
+
+  #[inline(always)]
+  fn on_end(
+    &mut self,
+    _metadata: &crate::ga::GAMetadata,
+    _population: &[crate::ga::Individual<T>],
+    _best_individual: &crate::ga::Individual<T>,
+  ) -> bool {
+    true
+  }
+}
+
+pub struct ElapsedTime {
+  interval: Duration,
+  threshold: Duration,
+  should_log: bool,
+}
+
+impl ElapsedTime {
+  /// Returns a new instance of [ElapsedTime] policy
+  ///
+  /// ### Arguments
+  ///
+  /// * `interval` - time between logging iterations
+  /// * `threshold` - time of first logging iteration
+  pub fn new(interval: Duration, threshold: Duration) -> Self {
+    Self {
+      interval,
+      threshold,
+      should_log: false,
+    }
+  }
+}
+
+impl<T: Chromosome> ProbingPolicy<T> for ElapsedTime {
+  #[inline(always)]
+  fn on_start(&mut self, _metadata: &crate::ga::GAMetadata) -> bool {
+    true
+  }
+
+  #[inline(always)]
+  fn on_initial_population_created(&mut self, _population: &[crate::ga::Individual<T>]) -> bool {
+    true
+  }
+
+  #[inline(always)]
+  fn on_new_best(
+    &mut self,
+    _metadata: &crate::ga::GAMetadata,
+    _individual: &crate::ga::Individual<T>,
+  ) -> bool {
+    true
+  }
+
+  #[inline(always)]
+  fn on_new_generation(&mut self, _generation: &[crate::ga::Individual<T>]) -> bool {
+    self.should_log
+  }
+
+  #[inline(always)]
+  fn on_best_fit_in_generation(
+    &mut self,
+    _metadata: &crate::ga::GAMetadata,
+    _individual: &crate::ga::Individual<T>,
+  ) -> bool {
+    self.should_log
+  }
+
+  fn on_iteration_start(&mut self, metadata: &GAMetadata) -> bool {
+    if metadata.duration.unwrap() >= self.threshold {
+      self.should_log = true;
+      self.threshold += self.interval;
+      true
+    } else {
+      false
+    }
+  }
+
+  #[inline]
+  fn on_iteration_end(&mut self, _metadata: &GAMetadata) -> bool {
     let prev = self.should_log;
     self.should_log = false;
     prev

--- a/src/ga/probe/probing_policy.rs
+++ b/src/ga/probe/probing_policy.rs
@@ -1,0 +1,88 @@
+use crate::ga::individual::Chromosome;
+
+use super::ProbingPolicy;
+
+pub struct GenerationInterval {
+  interval: usize,
+  threshold: usize,
+  should_log: bool,
+}
+
+impl GenerationInterval {
+  /// Returns new instance of [GenerationInverval] policy
+  ///
+  /// ### Arguments
+  ///
+  /// * `interval` - how many iteration should be skipped between logs
+  /// * `first_threshold` - number of first iteration to log
+  pub fn new(interval: usize, first_threshold: usize) -> Self {
+    Self {
+      interval,
+      threshold: first_threshold,
+      should_log: false,
+    }
+  }
+}
+
+impl<T: Chromosome> ProbingPolicy<T> for GenerationInterval {
+  #[inline(always)]
+  fn on_start(&mut self, _metadata: &crate::ga::GAMetadata) -> bool {
+    true
+  }
+
+  #[inline(always)]
+  fn on_initial_population_created(&mut self, _population: &[crate::ga::Individual<T>]) -> bool {
+    true
+  }
+
+  #[inline(always)]
+  fn on_new_best(
+    &mut self,
+    _metadata: &crate::ga::GAMetadata,
+    _individual: &crate::ga::Individual<T>,
+  ) -> bool {
+    true
+  }
+
+  #[inline(always)]
+  fn on_new_generation(&mut self, _generation: &[crate::ga::Individual<T>]) -> bool {
+    self.should_log
+  }
+
+  #[inline(always)]
+  fn on_best_fit_in_generation(
+    &mut self,
+    _metadata: &crate::ga::GAMetadata,
+    _individual: &crate::ga::Individual<T>,
+  ) -> bool {
+    self.should_log
+  }
+
+  #[inline]
+  fn on_iteration_start(&mut self, iteration: usize) -> bool {
+    if iteration >= self.threshold {
+      self.threshold += self.interval;
+      self.should_log = true;
+      true
+    } else {
+      false
+    }
+  }
+
+  #[inline(always)]
+  fn on_iteration_end(&mut self, _iteration: usize) -> bool {
+    let prev = self.should_log;
+    self.should_log = false;
+    prev
+  }
+
+  #[inline(always)]
+  fn on_end(
+    &mut self,
+    _metadata: &crate::ga::GAMetadata,
+    _population: &[crate::ga::Individual<T>],
+    _best_individual: &crate::ga::Individual<T>,
+  ) -> bool {
+    true
+  }
+}

--- a/src/ga/probe/stdout_probe.rs
+++ b/src/ga/probe/stdout_probe.rs
@@ -22,7 +22,7 @@ impl<T: Chromosome> Probe<T> for StdoutProbe {
     info!(
       "[NEW_BEST] {},{},{:?},{}",
       metadata.duration.unwrap().as_millis(),
-      metadata.generation.unwrap(),
+      metadata.generation,
       individual.chromosome_ref(),
       individual.fitness
     );
@@ -38,7 +38,7 @@ impl<T: Chromosome> Probe<T> for StdoutProbe {
     info!(
       "[BEST_IN_GEN] {},{},{:?},{}",
       metadata.duration.unwrap().as_millis(),
-      metadata.generation.unwrap(),
+      metadata.generation,
       individual.chromosome_ref(),
       individual.fitness
     );
@@ -53,7 +53,7 @@ impl<T: Chromosome> Probe<T> for StdoutProbe {
     info!(
       "[END] {},{},{:?},{}",
       metadata.duration.unwrap().as_millis(),
-      metadata.generation.unwrap(),
+      metadata.generation,
       best_individual.chromosome_ref(),
       best_individual.fitness
     );

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -14,7 +14,7 @@ fn generic_does_not_panic_with_some_params_unspecified() {
     .set_selection_operator(ecrs::ga::operators::selection::Boltzmann::new(
       0.05, 80.0, 500, false,
     ))
-    .set_probe(ecrs::ga::probe::stdout_probe::StdoutProbe)
+    .set_probe(ecrs::ga::probe::StdoutProbe)
     .build();
 
   // all params omitted
@@ -29,7 +29,7 @@ fn generic_does_not_panic_with_some_params_unspecified() {
     .set_selection_operator(ecrs::ga::operators::selection::Boltzmann::new(
       0.05, 80.0, 500, false,
     ))
-    .set_probe(ecrs::ga::probe::stdout_probe::StdoutProbe)
+    .set_probe(ecrs::ga::probe::StdoutProbe)
     .build();
 }
 

--- a/tests/selection_tests.rs
+++ b/tests/selection_tests.rs
@@ -181,7 +181,7 @@ fn boltzmann_returns_demanded_size() {
   );
 
   // FIXME: We must add mocking!
-  let metadata = GAMetadata::new(Some(std::time::Instant::now()), None, Some(40));
+  let metadata = GAMetadata::new(Some(std::time::Instant::now()), None, 40);
 
   let selected = Boltzmann::new(0.2, 6.0, 300, true).apply(&metadata, &population, expected_selection_size);
 


### PR DESCRIPTION
## Description

This PR extends probing mechanisms in GA and solutions introduced here should also be taken into consideration while implementing / extending logging mechanisms for other algorithms. 

* Added `ProbingPolicy` trait
* Added `GenerationInterval` probing policy
* Added `ElapsedTime` probing policy
* Added new `PolicyDrivenProbe` - this probe can be passed a `ProbingPolicy` and it will log only when given policy allows it to
* Changed the way probing are exported out of `crate::ga::probe` module - now they are exported directly, not via their designated module. That means old import: 

```rust
use ecrs::ga::probe::stdout_probe::StdoutProbe
```

now becomes

```rust
use ecrs::ga::probe::StdoutProbe
```

* Added Aggregated probe, which can be passed a vector of probes and executes them sequentially. 
* Minor refactors of codebase to make aforementioned changes possible.

## Linked issues

Resolves #171
Resolves #170 
