### PR TITLE
feat: `replacement` - improve interface & some fixes

### DIFF
--- a/src/ga.rs
+++ b/src/ga.rs
@@ -194,9 +194,9 @@ where
           .apply(&mut children[i], self.config.params.mutation_rate)
       });
 
-			if self.config.replacement_operator.requires_children_fitness() {
-				self.evaluate_population(&mut children);
-			}
+      if self.config.replacement_operator.requires_children_fitness() {
+        self.evaluate_population(&mut children);
+      }
 
       // 6. Replacement - merge new generation with old one
       population = self.config.replacement_operator.apply(population, children);

--- a/src/ga/builder/bistring.rs
+++ b/src/ga/builder/bistring.rs
@@ -1,6 +1,6 @@
 use crate::ga::builder::FitnessFn;
 use crate::ga::operators::fitness::{Fitness, FnBasedFitness};
-use crate::ga::operators::replacement::Noop;
+use crate::ga::operators::replacement::BothParents;
 use crate::ga::{
   operators::{crossover::SinglePoint, mutation::FlipBit, selection::Tournament},
   population::BitStrings,
@@ -18,7 +18,7 @@ pub struct BitStringBuilder<F: Fitness<Bsc>> {
     FlipBit<rand::rngs::ThreadRng>,
     SinglePoint<rand::rngs::ThreadRng>,
     Tournament<rand::rngs::ThreadRng>,
-    Noop,
+    BothParents,
     BitStrings<rand::rngs::ThreadRng>,
     F,
     StdoutProbe,
@@ -87,7 +87,7 @@ impl<F: Fitness<Bsc>> BitStringBuilder<F> {
     FlipBit<rand::rngs::ThreadRng>,
     SinglePoint<rand::rngs::ThreadRng>,
     Tournament<rand::rngs::ThreadRng>,
-    Noop,
+    BothParents,
     BitStrings<rand::rngs::ThreadRng>,
     F,
     StdoutProbe,
@@ -107,7 +107,7 @@ impl<F: Fitness<Bsc>> BitStringBuilder<F> {
       .config
       .selection_operator
       .get_or_insert_with(|| Tournament::new(0.2));
-    self.config.replacement_operator.get_or_insert_with(Noop::new);
+    self.config.replacement_operator.get_or_insert_with(BothParents::new);
     self
       .config
       .population_factory

--- a/src/ga/builder/bistring.rs
+++ b/src/ga/builder/bistring.rs
@@ -107,7 +107,10 @@ impl<F: Fitness<Bsc>> BitStringBuilder<F> {
       .config
       .selection_operator
       .get_or_insert_with(|| Tournament::new(0.2));
-    self.config.replacement_operator.get_or_insert_with(BothParents::new);
+    self
+      .config
+      .replacement_operator
+      .get_or_insert_with(BothParents::new);
     self
       .config
       .population_factory

--- a/src/ga/builder/realvalued.rs
+++ b/src/ga/builder/realvalued.rs
@@ -1,6 +1,6 @@
 use crate::ga::builder::FitnessFn;
 use crate::ga::operators::fitness::{Fitness, FnBasedFitness};
-use crate::ga::operators::replacement::Noop;
+use crate::ga::operators::replacement::BothParents;
 use crate::ga::{
   operators::{crossover::SinglePoint, mutation::Interchange, selection::Tournament},
   population::RandomPoints,
@@ -18,7 +18,7 @@ pub struct RealValuedBuilder<F: Fitness<Rvc>> {
     Interchange<rand::rngs::ThreadRng>,
     SinglePoint<rand::rngs::ThreadRng>,
     Tournament<rand::rngs::ThreadRng>,
-    Noop,
+    BothParents,
     RandomPoints<rand::rngs::ThreadRng>,
     F,
     StdoutProbe,
@@ -87,7 +87,7 @@ impl<F: Fitness<Rvc>> RealValuedBuilder<F> {
     Interchange<rand::rngs::ThreadRng>,
     SinglePoint<rand::rngs::ThreadRng>,
     Tournament<rand::rngs::ThreadRng>,
-    Noop,
+    BothParents,
     RandomPoints<rand::rngs::ThreadRng>,
     F,
     StdoutProbe,
@@ -111,7 +111,7 @@ impl<F: Fitness<Rvc>> RealValuedBuilder<F> {
       .config
       .selection_operator
       .get_or_insert_with(|| Tournament::new(0.2));
-    self.config.replacement_operator.get_or_insert_with(Noop::new);
+    self.config.replacement_operator.get_or_insert_with(BothParents::new);
     self
       .config
       .population_factory

--- a/src/ga/builder/realvalued.rs
+++ b/src/ga/builder/realvalued.rs
@@ -111,7 +111,10 @@ impl<F: Fitness<Rvc>> RealValuedBuilder<F> {
       .config
       .selection_operator
       .get_or_insert_with(|| Tournament::new(0.2));
-    self.config.replacement_operator.get_or_insert_with(BothParents::new);
+    self
+      .config
+      .replacement_operator
+      .get_or_insert_with(BothParents::new);
     self
       .config
       .population_factory

--- a/src/ga/operators/replacement.rs
+++ b/src/ga/operators/replacement.rs
@@ -31,12 +31,12 @@ pub trait ReplacementOperator<T: Chromosome> {
   /// * `children` - Result of the crossover phase.
   fn apply(&self, population: Vec<Individual<T>>, children: Vec<Individual<T>>) -> Vec<Individual<T>>;
 
-	/// Returns `true` when the operator requries children to possess valid fitness values.
-	///
-	/// Default implementation returns `false`
-	fn requires_children_fitness(&self) -> bool {
-		true
-	}
+  /// Returns `true` when the operator requries children to possess valid fitness values.
+  ///
+  /// Default implementation returns `false`
+  fn requires_children_fitness(&self) -> bool {
+    true
+  }
 }
 
 /// # BothParents replacement operator
@@ -55,7 +55,7 @@ impl BothParents {
 
 impl<T: Chromosome> ReplacementOperator<T> for BothParents {
   /// Works simply by replacing parents with their children
-	///
+  ///
   /// **NOTE**: In current implementation, all library-implemented operators assume that
   /// at indices i, i+1 in `population` collection there are parents of children i, i+1
   /// from `children` collection. Any violation of this invariant may lead to bugs - it can
@@ -68,14 +68,14 @@ impl<T: Chromosome> ReplacementOperator<T> for BothParents {
   /// * `children` - Result of the crossover phase
   #[inline(always)]
   fn apply(&self, _population: Vec<Individual<T>>, children: Vec<Individual<T>>) -> Vec<Individual<T>> {
-		children
-	}
+    children
+  }
 
-	/// Returns `false`.
-	#[inline(always)]
-	fn requires_children_fitness(&self) -> bool {
-		false
-	}
+  /// Returns `false`.
+  #[inline(always)]
+  fn requires_children_fitness(&self) -> bool {
+    false
+  }
 }
 
 /// # Noop replacement operator
@@ -94,6 +94,6 @@ impl Noop {
 impl<T: Chromosome> ReplacementOperator<T> for Noop {
   #[inline(always)]
   fn apply(&self, population: Vec<Individual<T>>, _children: Vec<Individual<T>>) -> Vec<Individual<T>> {
-		population
-	}
+    population
+  }
 }

--- a/src/ga/operators/replacement.rs
+++ b/src/ga/operators/replacement.rs
@@ -18,11 +18,6 @@ use crate::ga::{individual::Chromosome, Individual};
 /// be considered an undefined behaviour. We'll work toward improving this case in the future.
 pub trait ReplacementOperator<T: Chromosome> {
   /// Merges `children` - output of crossover operator with current population.
-  /// In current implementation (and design) the merge happens in place (where possible)
-  /// to avoid necessity of copying whole population each time the operator is called.
-  /// This might be a premature optimization and we will consider benchmarking this approach
-  /// and possibly making API more intuitive by making this function return the merged
-  /// population instead of modyfying in-place.
   ///
   /// **NOTE**: In current implementation, all library-implemented operators assume that
   /// at indices i, i+1 in `population` collection there are parents of children i, i+1
@@ -33,8 +28,15 @@ pub trait ReplacementOperator<T: Chromosome> {
   ///
   /// * `population` - Original population, input to the crossover phase.
   /// This collection should be modified in place by the operator.
-  /// * `children` - Result of the crossover phase
-  fn apply(&self, population: &mut [Individual<T>], children: &[Individual<T>]);
+  /// * `children` - Result of the crossover phase.
+  fn apply(&self, population: Vec<Individual<T>>, children: Vec<Individual<T>>) -> Vec<Individual<T>>;
+
+	/// Returns `true` when the operator requries children to possess valid fitness values.
+	///
+	/// Default implementation returns `false`
+	fn requires_children_fitness(&self) -> bool {
+		true
+	}
 }
 
 /// # BothParents replacement operator
@@ -43,8 +45,6 @@ pub trait ReplacementOperator<T: Chromosome> {
 ///
 /// It works simply by replacing parents with their children. In effect, each individual
 /// only gets to breed once.
-///
-/// This operator has the same effect as [Noop].
 pub struct BothParents;
 
 impl BothParents {
@@ -54,8 +54,28 @@ impl BothParents {
 }
 
 impl<T: Chromosome> ReplacementOperator<T> for BothParents {
+  /// Works simply by replacing parents with their children
+	///
+  /// **NOTE**: In current implementation, all library-implemented operators assume that
+  /// at indices i, i+1 in `population` collection there are parents of children i, i+1
+  /// from `children` collection. Any violation of this invariant may lead to bugs - it can
+  /// be considered an undefined behaviour. We'll work toward improving this case in the future.
+  ///
+  /// ### Arguements
+  ///
+  /// * `population` - Original population, input to the crossover phase.
+  /// This collection should be modified in place by the operator.
+  /// * `children` - Result of the crossover phase
   #[inline(always)]
-  fn apply(&self, _population: &mut [Individual<T>], _children: &[Individual<T>]) {}
+  fn apply(&self, _population: Vec<Individual<T>>, children: Vec<Individual<T>>) -> Vec<Individual<T>> {
+		children
+	}
+
+	/// Returns `false`.
+	#[inline(always)]
+	fn requires_children_fitness(&self) -> bool {
+		false
+	}
 }
 
 /// # Noop replacement operator
@@ -63,8 +83,6 @@ impl<T: Chromosome> ReplacementOperator<T> for BothParents {
 /// This struct implements [ReplacementOperator] trait and can be used with genetic algorithm.
 ///
 /// It does nothing. Implementation is a noop.
-///
-/// This operator is the same as [BothParents]. Can be treated as an alias.
 pub struct Noop;
 
 impl Noop {
@@ -75,5 +93,7 @@ impl Noop {
 
 impl<T: Chromosome> ReplacementOperator<T> for Noop {
   #[inline(always)]
-  fn apply(&self, _population: &mut [Individual<T>], _children: &[Individual<T>]) {}
+  fn apply(&self, population: Vec<Individual<T>>, _children: Vec<Individual<T>>) -> Vec<Individual<T>> {
+		population
+	}
 }

--- a/src/ga/operators/replacement.rs
+++ b/src/ga/operators/replacement.rs
@@ -97,8 +97,8 @@ impl<T: Chromosome> ReplacementOperator<T> for Noop {
     population
   }
 
-	#[inline(always)]
-	fn requires_children_fitness(&self) -> bool {
-		false
-	}
+  #[inline(always)]
+  fn requires_children_fitness(&self) -> bool {
+    false
+  }
 }

--- a/src/ga/operators/replacement.rs
+++ b/src/ga/operators/replacement.rs
@@ -96,4 +96,9 @@ impl<T: Chromosome> ReplacementOperator<T> for Noop {
   fn apply(&self, population: Vec<Individual<T>>, _children: Vec<Individual<T>>) -> Vec<Individual<T>> {
     population
   }
+
+	#[inline(always)]
+	fn requires_children_fitness(&self) -> bool {
+		false
+	}
 }


### PR DESCRIPTION
## Description

So I've just merged #263 skipping review process 🤦🏻‍♂️  and had to immediately introduce some fixes;

1. I decided to take ownership of population & children, so that I can modify it in the operator and avoid necessity of creating a copy.
2. Added `requires_children_fitness` method which indicated whether children's fitness should be evaluated.
3. Fixed `BothParents` implementation