### PR TITLE
refact(FF): rename `execute` -> `run`

### DIFF
--- a/examples/ff.rs
+++ b/examples/ff.rs
@@ -3,5 +3,5 @@ use ecrs::ff::FireflyAlgorithm;
 fn main() {
   let mut alg = FireflyAlgorithm::default();
 
-  alg.execute();
+  alg.run();
 }

--- a/examples/ff_logging.rs
+++ b/examples/ff_logging.rs
@@ -22,5 +22,5 @@ fn main() {
     distance_function: cartesian_distance,
   };
 
-  alg.execute();
+  alg.run();
 }

--- a/src/ff.rs
+++ b/src/ff.rs
@@ -100,7 +100,7 @@ where
     }
   }
 
-  pub fn execute(&mut self) {
+  pub fn run(&mut self) {
     self.probe.on_start();
     let mut population: Vec<Vec<f64>> = Vec::new();
 


### PR DESCRIPTION
## Description

Introducing more consistent naming with other algorithms.

## Linked issues

Resolves #305
