### PR TITLE
feat: add basic prelude module

### DIFF
--- a/coco/src/main.rs
+++ b/coco/src/main.rs
@@ -3,8 +3,7 @@
 mod adapter;
 
 use coco_rs::{LogLevel, Observer, ObserverName, Problem, RandomState, Suite, SuiteName};
-use ecrs::ga::operators;
-use ecrs::ga::population;
+use ecrs::prelude::*;
 
 const BUDGET_MULTIPLIER: usize = 10;
 const INDEPENDENT_RESTARTS_100K: u64 = 1e5 as u64;
@@ -112,10 +111,10 @@ fn ecrs_ga_search(problem: &mut Problem, _max_budget: usize, _random_generator: 
       dimension,
       constraints,
     ))
-    .set_selection_operator(operators::selection::Tournament::new(0.2))
-    .set_crossover_operator(operators::crossover::Uniform::new())
-    .set_mutation_operator(operators::mutation::Reversing::new())
-    .set_replacement_operator(operators::replacement::WeakParent::new())
+    .set_selection_operator(selection::Tournament::new(0.2))
+    .set_crossover_operator(crossover::Uniform::new())
+    .set_mutation_operator(mutation::Reversing::new())
+    .set_replacement_operator(replacement::WeakParent::new())
     .build();
 
   solver.run();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,12 @@
+//! # ECRS - Evolutionary Computation for Rust
+//!
+//! Evolutionary computation tools & algorithms (also some bioinspired ones)
+//!
+//! ## Disclaimer
+//!
+//! Please note that this library is in early development phase
+//! and breaking changes may occur without nay notice.
+
 #![allow(dead_code)]
 #![allow(clippy::new_without_default)]
 #![allow(clippy::type_complexity)]
@@ -7,5 +16,6 @@ extern crate core;
 pub mod aco;
 pub mod ff;
 pub mod ga;
+pub mod prelude;
 pub mod pso;
 pub mod test_functions;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,14 @@
+//! Convinence reexports for common used types & functions
+//!
+//! ## Usage
+//!
+//! ```
+//! use rand::prelude::*;
+//! ```
+
+pub use crate::aco;
+pub use crate::ff;
+pub use crate::ga;
+pub use crate::ga::operators::{crossover, fitness, mutation, replacement, selection};
+pub use crate::pso;
+pub use crate::test_functions as tf;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,6 +9,8 @@
 pub use crate::aco;
 pub use crate::ff;
 pub use crate::ga;
+pub use crate::ga::operators as ops;
 pub use crate::ga::operators::{crossover, fitness, mutation, replacement, selection};
+pub use crate::ga::population;
 pub use crate::pso;
 pub use crate::test_functions as tf;


### PR DESCRIPTION
<!-- If applicable - remeber to add the PR to the EA Rust project (ONLY IF THERE IS NO LINKED ISSUE) -->

## Description

I did not want to re-export more submodules as their names are identical e.g. ga::probe, pso::probe... 

Maybe we should consider doing some refactoring. 

## Linked issues

Resolves #330 