### PR TITLE
feat(GA): implement `UniformParameterized` crossover operator

### DIFF
--- a/src/ga/operators/crossover.rs
+++ b/src/ga/operators/crossover.rs
@@ -468,11 +468,7 @@ where
     let mut child_1: Individual<ChT> = Individual::new();
     let mut child_2: Individual<ChT> = Individual::new();
 
-    let mask = self
-      .rng
-      .clone()
-      .sample_iter(self.distr)
-      .take(chromosome_len);
+    let mask = self.rng.clone().sample_iter(self.distr).take(chromosome_len);
 
     for (locus, val) in mask.enumerate() {
       if val <= self.bias {


### PR DESCRIPTION
## Description

Added implementation of `UniformParameterized` crossover operator. 
It is now possible to specify the bias for rng when generating bitmask.

