### PR TITLE
feat: add population::tools module with methods for primitive chromosome generation

### DIFF
--- a/src/ga/population.rs
+++ b/src/ga/population.rs
@@ -126,11 +126,7 @@ impl<IndividualT: IndividualTrait<ChromosomeT = Vec<f64>>, R: Rng + Clone> Popul
     /// * `count` -- Number of points to generate
     fn generate(&mut self, count: usize) -> Vec<IndividualT> {
         tools::PointGenerator::with_rng(self.rng.clone())
-            .generate_with_constraints(
-                self.dim,
-                count,
-                &self.constraints
-            )
+            .generate_with_constraints(self.dim, count, &self.constraints)
             .into_iter()
             .map(|chromosome| IndividualT::from(chromosome))
             .collect_vec()

--- a/src/ga/population.rs
+++ b/src/ga/population.rs
@@ -19,7 +19,7 @@ pub trait PopulationGenerator<IndividualT: IndividualTrait> {
 /// Generates vector of random points from R^(dim) space within passed domain constraints.
 pub struct RandomPoints<R: Rng = ThreadRng> {
     dim: usize,
-    constraints: Vec<(f64, f64)>,
+    constraints: Vec<Range<f64>>,
     rng: R,
 }
 
@@ -48,7 +48,7 @@ impl RandomPoints<ThreadRng> {
     pub fn with_constraints_inclusive(dim: usize, constraints: Vec<RangeInclusive<f64>>) -> Self {
         let noninclusive = constraints
             .into_iter()
-            .map(|r| (*r.start()..*r.end()))
+            .map(|r| *r.start()..*r.end())
             .collect_vec();
         Self::with_constraints_and_rng(dim, noninclusive, thread_rng())
     }
@@ -61,8 +61,7 @@ impl RandomPoints<ThreadRng> {
     /// * `dim` -- Dimension of the sampling space
     /// * `constraint` -- Range for coordinates
     pub fn with_single_constraint(dim: usize, constraint: Range<f64>) -> Self {
-        let constraints = (1..=dim).map(|_| constraint.clone()).collect();
-        Self::with_constraints(dim, constraints)
+        Self::with_constraints(dim, std::iter::repeat(constraint).collect())
     }
 
     /// Returns [RandomPoints] population generator with no explicit constraints and default RNG.
@@ -94,10 +93,7 @@ impl<R: Rng> RandomPoints<R> {
 
         RandomPoints {
             dim,
-            constraints: constraints
-                .into_iter()
-                .map(|range| (range.end - range.start, range.start))
-                .collect_vec(),
+            constraints,
             rng,
         }
     }
@@ -113,7 +109,7 @@ impl<R: Rng> RandomPoints<R> {
         assert!(dim > 0, "Space dimension must be > 0");
         RandomPoints {
             dim,
-            constraints: Vec::<(f64, f64)>::with_capacity(0),
+            constraints: Vec::from_iter(std::iter::repeat(0.0..1.0)),
             rng,
         }
     }
@@ -133,10 +129,7 @@ impl<IndividualT: IndividualTrait<ChromosomeT = Vec<f64>>, R: Rng + Clone> Popul
             .generate_with_constraints(
                 self.dim,
                 count,
-                self.constraints
-                    .iter()
-                    .map(|(start, end)| *start..*end)
-                    .collect_vec(),
+                &self.constraints
             )
             .into_iter()
             .map(|chromosome| IndividualT::from(chromosome))

--- a/src/ga/population.rs
+++ b/src/ga/population.rs
@@ -61,7 +61,7 @@ impl RandomPoints<ThreadRng> {
     /// * `dim` -- Dimension of the sampling space
     /// * `constraint` -- Range for coordinates
     pub fn with_single_constraint(dim: usize, constraint: Range<f64>) -> Self {
-        Self::with_constraints(dim, std::iter::repeat(constraint).collect())
+        Self::with_constraints(dim, std::iter::repeat(constraint).take(dim).collect())
     }
 
     /// Returns [RandomPoints] population generator with no explicit constraints and default RNG.
@@ -109,7 +109,7 @@ impl<R: Rng> RandomPoints<R> {
         assert!(dim > 0, "Space dimension must be > 0");
         RandomPoints {
             dim,
-            constraints: Vec::from_iter(std::iter::repeat(0.0..1.0)),
+            constraints: Vec::from_iter(std::iter::repeat(0.0..1.0).take(dim)),
             rng,
         }
     }

--- a/src/ga/population/tools.rs
+++ b/src/ga/population/tools.rs
@@ -28,14 +28,14 @@ impl<R: Rng + Clone> PointGenerator<R> {
         n: usize,
         constraint: Range<f64>,
     ) -> Vec<Vec<f64>> {
-        self.generate_with_constraints(dim, n, Vec::from_iter(std::iter::repeat(constraint)))
+        self.generate_with_constraints(dim, n, &Vec::from_iter(std::iter::repeat(constraint)))
     }
 
     pub fn generate_with_constraints(
         &self,
         dim: usize,
         n: usize,
-        constraints: Vec<Range<f64>>,
+        constraints: &Vec<Range<f64>>,
     ) -> Vec<Vec<f64>> {
         assert_eq!(n, constraints.len());
         Vec::from_iter(constraints.iter().map(|constr| {

--- a/src/ga/population/tools.rs
+++ b/src/ga/population/tools.rs
@@ -8,25 +8,26 @@ pub struct PointGenerator<R: Rng = ThreadRng> {
 }
 
 impl PointGenerator<ThreadRng> {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self::with_rng(thread_rng())
     }
 }
 
 impl<R: Rng + Clone> PointGenerator<R> {
-    fn with_rng(rng: R) -> Self {
+    pub fn with_rng(rng: R) -> Self {
         Self { rng }
     }
 
-    fn generate(&self, dim: usize, n: usize) -> Vec<Vec<f64>> {
+    pub fn generate(&self, dim: usize, n: usize) -> Vec<Vec<f64>> {
         self.generate_with_single_constraint(dim, n, 0.0..1.0)
     }
 
-    fn generate_with_single_constraint(&self, dim: usize, n: usize, constraint: Range<f64>) -> Vec<Vec<f64>> {
+    pub fn generate_with_single_constraint(&self, dim: usize, n: usize, constraint: Range<f64>) -> Vec<Vec<f64>> {
         self.generate_with_constraints(dim, n, Vec::from_iter(std::iter::repeat(constraint)))
     }
 
-    fn generate_with_constraints(&self, dim: usize, n: usize, constraints: Vec<Range<f64>>) -> Vec<Vec<f64>> {
+    pub fn generate_with_constraints(&self, dim: usize, n: usize, constraints: Vec<Range<f64>>) -> Vec<Vec<f64>> {
+        assert_eq!(n, constraints.len());
         Vec::from_iter(constraints.iter().map(|constr| {
             self.rng
                 .clone()

--- a/src/ga/population/tools.rs
+++ b/src/ga/population/tools.rs
@@ -1,0 +1,38 @@
+use std::ops::Range;
+
+use itertools::Itertools;
+use rand::{rngs::ThreadRng, thread_rng, Rng};
+
+pub struct PointGenerator<R: Rng = ThreadRng> {
+    rng: R,
+}
+
+impl PointGenerator<ThreadRng> {
+    fn new() -> Self {
+        Self::with_rng(thread_rng())
+    }
+}
+
+impl<R: Rng + Clone> PointGenerator<R> {
+    fn with_rng(rng: R) -> Self {
+        Self { rng }
+    }
+
+    fn generate(&self, dim: usize, n: usize) -> Vec<Vec<f64>> {
+        self.generate_with_single_constraint(dim, n, 0.0..1.0)
+    }
+
+    fn generate_with_single_constraint(&self, dim: usize, n: usize, constraint: Range<f64>) -> Vec<Vec<f64>> {
+        self.generate_with_constraints(dim, n, Vec::from_iter(std::iter::repeat(constraint)))
+    }
+
+    fn generate_with_constraints(&self, dim: usize, n: usize, constraints: Vec<Range<f64>>) -> Vec<Vec<f64>> {
+        Vec::from_iter(constraints.iter().map(|constr| {
+            self.rng
+                .clone()
+                .sample_iter(rand::distributions::Uniform::new(constr.start, constr.end))
+                .take(dim)
+                .collect_vec()
+        }))
+    }
+}

--- a/src/ga/population/tools.rs
+++ b/src/ga/population/tools.rs
@@ -1,6 +1,5 @@
 use std::ops::Range;
 
-use itertools::Itertools;
 use rand::{rngs::ThreadRng, thread_rng, Rng};
 
 pub struct PointGenerator<R: Rng = ThreadRng> {
@@ -106,19 +105,17 @@ mod tests {
         let dim: usize = 20;
         let n: usize = 100;
 
-        let count = PointGenerator::new().generate(dim, n).iter().count();
+        let count = PointGenerator::new().generate(dim, n).len();
         assert_eq!(count, n);
 
         let count = PointGenerator::new()
             .generate_with_constraints(dim, n, &std::iter::repeat(-1.0..1.0).take(dim).collect())
-            .iter()
-            .count();
+            .len();
         assert_eq!(count, n);
 
         let count = PointGenerator::new()
             .generate_with_single_constraint(dim, n, -2.0..2.0)
-            .iter()
-            .count();
+            .len();
         assert_eq!(count, n);
     }
 }

--- a/src/ga/population/tools.rs
+++ b/src/ga/population/tools.rs
@@ -1,26 +1,35 @@
+//! Tools for primitive chromosomes generation. These are meant mainly for internal usage
+//! by [population generators][PopulationGenerators] but they also might be of some help for you.
+//!
+//! [PopulationGenerators]: super::PopulationGenerator
 use std::ops::Range;
 
 use rand::{rngs::ThreadRng, thread_rng, Rng};
 
+/// Random point generator. Just that.
 pub struct PointGenerator<R: Rng = ThreadRng> {
     rng: R,
 }
 
 impl PointGenerator<ThreadRng> {
+    /// Returns instance of [PointGenerator] with ThreadRng as default RNG.
     pub fn new() -> Self {
         Self::with_rng(thread_rng())
     }
 }
 
 impl<R: Rng + Clone> PointGenerator<R> {
+    /// Returns new instance of [PointGenerator with given RNG.
     pub fn with_rng(rng: R) -> Self {
         Self { rng }
     }
 
+    /// Generates `n` random points, each with `dim` coordinates from range [0.0, 1.0).
     pub fn generate(&mut self, dim: usize, n: usize) -> Vec<Vec<f64>> {
         self.generate_with_single_constraint(dim, n, 0.0..1.0)
     }
 
+    /// Generates `n` random points, each with `dim` coordinates from given range.
     pub fn generate_with_single_constraint(
         &mut self,
         dim: usize,
@@ -30,6 +39,8 @@ impl<R: Rng + Clone> PointGenerator<R> {
         self.generate_with_constraints(dim, n, &Vec::from_iter(std::iter::repeat(constraint).take(dim)))
     }
 
+    /// Generates `n` random points, each with `dim` coordinates. Each coordinate respects given
+    /// constraint.
     pub fn generate_with_constraints(
         &mut self,
         dim: usize,

--- a/src/ga/population/tools.rs
+++ b/src/ga/population/tools.rs
@@ -22,11 +22,21 @@ impl<R: Rng + Clone> PointGenerator<R> {
         self.generate_with_single_constraint(dim, n, 0.0..1.0)
     }
 
-    pub fn generate_with_single_constraint(&self, dim: usize, n: usize, constraint: Range<f64>) -> Vec<Vec<f64>> {
+    pub fn generate_with_single_constraint(
+        &self,
+        dim: usize,
+        n: usize,
+        constraint: Range<f64>,
+    ) -> Vec<Vec<f64>> {
         self.generate_with_constraints(dim, n, Vec::from_iter(std::iter::repeat(constraint)))
     }
 
-    pub fn generate_with_constraints(&self, dim: usize, n: usize, constraints: Vec<Range<f64>>) -> Vec<Vec<f64>> {
+    pub fn generate_with_constraints(
+        &self,
+        dim: usize,
+        n: usize,
+        constraints: Vec<Range<f64>>,
+    ) -> Vec<Vec<f64>> {
         assert_eq!(n, constraints.len());
         Vec::from_iter(constraints.iter().map(|constr| {
             self.rng

--- a/src/ga/population/tools.rs
+++ b/src/ga/population/tools.rs
@@ -18,32 +18,107 @@ impl<R: Rng + Clone> PointGenerator<R> {
         Self { rng }
     }
 
-    pub fn generate(&self, dim: usize, n: usize) -> Vec<Vec<f64>> {
+    pub fn generate(&mut self, dim: usize, n: usize) -> Vec<Vec<f64>> {
         self.generate_with_single_constraint(dim, n, 0.0..1.0)
     }
 
     pub fn generate_with_single_constraint(
-        &self,
+        &mut self,
         dim: usize,
         n: usize,
         constraint: Range<f64>,
     ) -> Vec<Vec<f64>> {
-        self.generate_with_constraints(dim, n, &Vec::from_iter(std::iter::repeat(constraint)))
+        self.generate_with_constraints(dim, n, &Vec::from_iter(std::iter::repeat(constraint).take(dim)))
     }
 
     pub fn generate_with_constraints(
-        &self,
+        &mut self,
         dim: usize,
         n: usize,
         constraints: &Vec<Range<f64>>,
     ) -> Vec<Vec<f64>> {
-        assert_eq!(n, constraints.len());
-        Vec::from_iter(constraints.iter().map(|constr| {
-            self.rng
-                .clone()
-                .sample_iter(rand::distributions::Uniform::new(constr.start, constr.end))
-                .take(dim)
-                .collect_vec()
+        assert_eq!(dim, constraints.len());
+        let distr = rand::distributions::Uniform::new(0.0, 1.0);
+        Vec::from_iter((0..n).map(|_| {
+            constraints
+                .iter()
+                .map(|constr| (constr.end - constr.start) * self.rng.sample(distr) + constr.start)
+                .collect()
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PointGenerator;
+
+    #[test]
+    fn points_have_correct_length() {
+        let dim: usize = 40;
+        let n: usize = 100;
+
+        PointGenerator::new()
+            .generate(dim, n)
+            .into_iter()
+            .for_each(|point| assert_eq!(point.len(), dim));
+    }
+
+    #[test]
+    fn points_follow_implicit_constraints() {
+        let dim: usize = 20;
+        let n: usize = 100;
+
+        PointGenerator::new()
+            .generate(dim, n)
+            .into_iter()
+            .for_each(|point| point.iter().for_each(|x| assert!((0.0..1.0).contains(x))));
+    }
+
+    #[test]
+    fn points_follow_single_constraint() {
+        let dim: usize = 20;
+        let n: usize = 100;
+        let constraint = -5.0..15.0;
+
+        PointGenerator::new()
+            .generate_with_single_constraint(dim, n, constraint.clone())
+            .into_iter()
+            .for_each(|point| point.iter().for_each(|x| assert!(constraint.contains(x))));
+    }
+
+    #[test]
+    fn points_follow_multiple_constraints() {
+        let dim: usize = 20;
+        let n: usize = 100;
+
+        PointGenerator::new().generate_with_constraints(
+            dim,
+            n,
+            &std::iter::repeat(-2.0..3.0)
+                .take(dim / 2)
+                .chain(std::iter::repeat(3.0..40.0).take(dim / 2))
+                .collect(),
+        );
+    }
+
+    #[test]
+    fn right_number_of_points_is_generated() {
+        let dim: usize = 20;
+        let n: usize = 100;
+
+        let count = PointGenerator::new().generate(dim, n).iter().count();
+        assert_eq!(count, n);
+
+        let count = PointGenerator::new()
+            .generate_with_constraints(dim, n, &std::iter::repeat(-1.0..1.0).take(dim).collect())
+            .iter()
+            .count();
+        assert_eq!(count, n);
+
+        let count = PointGenerator::new()
+            .generate_with_single_constraint(dim, n, -2.0..2.0)
+            .iter()
+            .count();
+        assert_eq!(count, n);
     }
 }


### PR DESCRIPTION
## Description

Added `population::tools` module for primitive chromosome generation (currently only random points)

Resolves #371
Resolves #370
