### PR TITLE
fix: set duration before first on_new_best call

### DIFF
--- a/src/ga.rs
+++ b/src/ga.rs
@@ -263,6 +263,7 @@ where
 
         let mut best_individual_all_time = Self::find_best_individual(&population).clone();
 
+        self.metadata.duration = Some(self.metadata.start_time.unwrap().elapsed());
         self.config
             .probe
             .on_new_best(&self.metadata, &best_individual_all_time);


### PR DESCRIPTION
<!-- If applicable - remember to add the PR to the EA Rust project (ONLY IF THERE IS NO LINKED ISSUE) -->

## Description

<!-- Please describe the motivation & changes introduced by this PR -->

## Linked issues

<!-- Please use "Resolves #<issue_no> syntax in case this PR should be linked to an issue -->

## Important implementation details

<!-- if any, optional section -->
