### PR TITLE
fix: inconsistences in individual comparison

### DIFF
--- a/examples/jssp/problem/individual.rs
+++ b/examples/jssp/problem/individual.rs
@@ -333,7 +333,7 @@ impl JsspIndividual {
             // Update the scheduling time t_g associated with g
             t_g = *finish_times.iter().filter(|&&t| t > t_g).min().unwrap();
         }
-        let makespan = usize::max(last_finish_time, self.local_search());
+        let makespan = usize::min(last_finish_time, self.local_search());
         self.fitness = makespan;
         self.is_fitness_valid = true;
 

--- a/src/ga.rs
+++ b/src/ga.rs
@@ -221,6 +221,8 @@ where
     pub fn new(
         config: GAConfig<IndividualT, MutOpT, CrossOpT, SelOpT, ReplOpT, PopGenT, FitnessT, ProbeT>,
     ) -> Self {
+        assert_eq!(config.params.population_size % 2, 0); // Required for most of operators right
+                                                          // now
         GeneticSolver {
             config,
             metadata: GAMetadata::new(None, None, 0),
@@ -230,7 +232,7 @@ where
     fn find_best_individual(population: &[IndividualT]) -> &IndividualT {
         let mut best_individual = &population[0];
         for idv in population.iter().skip(1) {
-            if *idv > *best_individual {
+            if *idv < *best_individual {
                 best_individual = idv;
             }
         }

--- a/src/ga.rs
+++ b/src/ga.rs
@@ -229,17 +229,12 @@ where
         }
     }
 
+    #[inline]
     fn find_best_individual(population: &[IndividualT]) -> &IndividualT {
-        let mut best_individual = &population[0];
-        for idv in population.iter().skip(1) {
-            if *idv < *best_individual {
-                best_individual = idv;
-            }
-        }
-        best_individual
+        population.iter().min().unwrap()
     }
 
-    #[inline(always)]
+    #[inline]
     fn eval_pop(&mut self, population: &mut [IndividualT]) {
         population
             .iter_mut()

--- a/src/ga.rs
+++ b/src/ga.rs
@@ -315,7 +315,7 @@ where
                 .probe
                 .on_best_fit_in_generation(&self.metadata, best_individual);
 
-            if *best_individual > best_individual_all_time {
+            if *best_individual < best_individual_all_time {
                 best_individual_all_time = best_individual.clone();
                 self.config
                     .probe

--- a/src/ga/probe/stdout_probe.rs
+++ b/src/ga/probe/stdout_probe.rs
@@ -33,15 +33,15 @@ impl<IndividualT: IndividualTrait> Probe<IndividualT> for StdoutProbe {
         // We don't want to print anything on new generation right now
     }
 
-    fn on_best_fit_in_generation(&mut self, _metadata: &GAMetadata, _individuall: &IndividualT) {
+    fn on_best_fit_in_generation(&mut self, metadata: &GAMetadata, individual: &IndividualT) {
         // TODO: Take reference to the best chromosome & display it here!
-        // info!(
-        //     "[BEST_IN_GEN] {},{},{:?},{}",
-        //     metadata.duration.unwrap().as_millis(),
-        //     metadata.generation,
-        //     individual.chromosome(),
-        //     individual.fitness()
-        // );
+        info!(
+            "[BEST_IN_GEN] {},{},{:?},{}",
+            metadata.duration.unwrap().as_millis(),
+            metadata.generation,
+            individual.chromosome(),
+            individual.fitness()
+        );
     }
 
     fn on_end(&mut self, metadata: &GAMetadata, _population: &[IndividualT], best_individual: &IndividualT) {

--- a/src/ga/probe/stdout_probe.rs
+++ b/src/ga/probe/stdout_probe.rs
@@ -33,15 +33,15 @@ impl<IndividualT: IndividualTrait> Probe<IndividualT> for StdoutProbe {
         // We don't want to print anything on new generation right now
     }
 
-    fn on_best_fit_in_generation(&mut self, metadata: &GAMetadata, individual: &IndividualT) {
+    fn on_best_fit_in_generation(&mut self, _metadata: &GAMetadata, _individuall: &IndividualT) {
         // TODO: Take reference to the best chromosome & display it here!
-        info!(
-            "[BEST_IN_GEN] {},{},{:?},{}",
-            metadata.duration.unwrap().as_millis(),
-            metadata.generation,
-            individual.chromosome(),
-            individual.fitness()
-        );
+        // info!(
+        //     "[BEST_IN_GEN] {},{},{:?},{}",
+        //     metadata.duration.unwrap().as_millis(),
+        //     metadata.generation,
+        //     individual.chromosome(),
+        //     individual.fitness()
+        // );
     }
 
     fn on_end(&mut self, metadata: &GAMetadata, _population: &[IndividualT], best_individual: &IndividualT) {


### PR DESCRIPTION
## Description

Currently there are few places in the code that try to achieve contradictory optimization targets: some operators treat "lesser" individuals as better, some treat "greater" ones as better.

This PR aims to clean things up and target only minimization ("lesser" individuals are "better").

Maximization can be achieved by implementing custom individual type with custom `Ord` trait implementation.

TODO: Implement MinIndividual & MaxIndividual types in the ecrs library, so both types of optimalization are available for user out of the box.

## Linked issues


## Important implementation details

