### PR TITLE
fix(jssp): remove redundant param in  func

### DIFF
--- a/examples/jssp/problem.rs
+++ b/examples/jssp/problem.rs
@@ -89,7 +89,7 @@ pub struct Machine {
 }
 
 impl Machine {
-    pub fn new(id: usize, _rmc_capacity: usize) -> Self {
+    pub fn new(id: usize) -> Self {
         Self {
             id,
             // rmc: vec![1; rmc_capacity],

--- a/examples/jssp/problem/population.rs
+++ b/examples/jssp/problem/population.rs
@@ -64,7 +64,7 @@ impl PopulationGenerator<JsspIndividual> for JsspPopProvider {
                 JsspIndividual::new(
                     chromosome,
                     operations.clone(),
-                    Vec::from_iter((0..instance.cfg.n_machines).map(|i| Machine::new(i, 5000))),
+                    Vec::from_iter((0..instance.cfg.n_machines).map(Machine::new)),
                     usize::MAX,
                 )
             })


### PR DESCRIPTION
## Description

`Machine::new` method had redundant parameter.

## Linked issues

Resolves #390

## Important implementation details

<!-- if any, optional section -->
