### PR TITLE
feat(jssp): refact `JsspPopProvider` & infer population size for given instance automaticaly

### DIFF
--- a/examples/jssp/main.rs
+++ b/examples/jssp/main.rs
@@ -25,17 +25,20 @@ use problem::population::JsspPopProvider;
 
 use crate::problem::{JsspConfig, JsspInstance};
 
-fn run_with_ecrs(path: PathBuf) {
+fn run_with_ecrs(instance: JsspInstance) {
+    let pop_size = instance.cfg.n_ops * 2;
+
     let mut solver = ga::Builder::new()
         .set_selection_operator(selection::Rank::new())
         .set_crossover_operator(JsspCrossover::new())
         .set_mutation_operator(mutation::Identity::new())
         .set_replacement_operator(replacement::BothParents::new())
-        .set_population_generator(JsspPopProvider::new(path))
+        .set_population_generator(JsspPopProvider::new(instance))
         .set_fitness(JsspFitness::new())
         .set_probe(ga::probe::StdoutProbe::new())
         .set_max_duration(std::time::Duration::from_secs(30))
-        .set_population_size(200)
+        .set_max_generation_count(400)
+        .set_population_size(pop_size)
         .build();
 
     solver.run();
@@ -55,7 +58,7 @@ fn run() {
         for op in instance.jobs.iter() {
             info!("{op:?}");
         }
-        run_with_ecrs(file);
+        run_with_ecrs(instance);
     }
 }
 

--- a/examples/jssp/main.rs
+++ b/examples/jssp/main.rs
@@ -54,7 +54,7 @@ fn run() {
     let args = cli::parse_args();
 
     if let Some(file) = args.file {
-        let instance = JsspInstance::try_from(file.clone()).unwrap();
+        let instance = JsspInstance::try_from(file).unwrap();
         for op in instance.jobs.iter() {
             info!("{op:?}");
         }

--- a/examples/jssp/parse.rs
+++ b/examples/jssp/parse.rs
@@ -50,13 +50,7 @@ impl TryFrom<PathBuf> for JsspInstance {
             .collect_vec();
         assert!(first_line.len() == 2);
 
-        let cfg = JsspConfig {
-            n_jobs: first_line[0],
-            n_machines: first_line[1],
-        };
-
         let mut jobs: Vec<Vec<Operation>> = Vec::new();
-
         let mut op_id: usize = 0;
         let mut job_id: usize = 0;
 
@@ -79,6 +73,12 @@ impl TryFrom<PathBuf> for JsspInstance {
                 });
             job_id += 1;
         });
+
+        let cfg = JsspConfig {
+            n_jobs: first_line[0],
+            n_machines: first_line[1],
+            n_ops: op_id,
+        };
 
         Ok(JsspInstance {
             jobs,

--- a/examples/jssp/problem.rs
+++ b/examples/jssp/problem.rs
@@ -132,6 +132,7 @@ impl Machine {
 pub struct JsspConfig {
     pub n_jobs: usize,
     pub n_machines: usize,
+    pub n_ops: usize,
 }
 
 #[derive(Debug)]

--- a/examples/jssp/problem/population.rs
+++ b/examples/jssp/problem/population.rs
@@ -14,7 +14,7 @@ pub struct JsspPopProvider {
 }
 
 impl JsspPopProvider {
-    pub fn new(instance: JsspInstance) -> Self {
+    pub fn new(mut instance: JsspInstance) -> Self {
         // Finding dimension of the chromosome
         let dim: usize = instance.jobs.iter().map(|job| job.len()).sum();
 


### PR DESCRIPTION
## Description

1. Refactored `JsspPopProvider` so that it is now created from `JsspInstance` and not from file path. 
2. Implemented `TryFrom<PathBuf>` for `JsspPopProvider` so that loading directly from path file is still possible.
3. Moved all `JsspInstance` adapting logic from `generate` method to `new` method so that repeated generation is much cheaper.
4. Added simple mechanism to infer population size for the solver automaticaly for the given problem instance (due to rules described in the paper).

## Linked issues

Closes #389

