### PR TITLE
fix(ci): attempt to fix add-issue-to-project workflow

### DIFF
--- a/.github/workflows/add-issue-to-project.yaml
+++ b/.github/workflows/add-issue-to-project.yaml
@@ -16,4 +16,5 @@ jobs:
           project-url: https://github.com/orgs/ecrs-org/projects/1
           labeled: bug, feature
           label-operator: OR
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Description

Attempt to fix `add-issue-to-project' workflow by adding missing `github-token` prop

## Linked issues

<!-- Please use "Resolves #<issue_no> syntax in case this PR should be linked to an issue -->

## Important implementation details

<!-- if any, optional section -->
