### PR TITLE
feat(ga): add `generate_iter` method on `PopulationGenerator` trait

### DIFF
--- a/src/ga/population.rs
+++ b/src/ga/population.rs
@@ -12,6 +12,10 @@ use super::individual::IndividualTrait;
 /// and feed it to an solver.
 pub trait PopulationGenerator<IndividualT: IndividualTrait> {
     fn generate(&mut self, count: usize) -> Vec<IndividualT>;
+
+    fn generate_iter(&mut self, count: usize) -> impl Iterator<Item = IndividualT> {
+        self.generate().into_iter()
+    }
 }
 
 /// Implements [PopulationGenerator] trait. Can be used with genetic algorithm.

--- a/src/ga/population.rs
+++ b/src/ga/population.rs
@@ -5,6 +5,7 @@ use rand::seq::SliceRandom;
 use rand::{thread_rng, Rng};
 use std::fmt::Debug;
 use std::ops::{Range, RangeInclusive};
+use std::vec::IntoIter;
 
 use super::individual::IndividualTrait;
 
@@ -13,8 +14,8 @@ use super::individual::IndividualTrait;
 pub trait PopulationGenerator<IndividualT: IndividualTrait> {
     fn generate(&mut self, count: usize) -> Vec<IndividualT>;
 
-    fn generate_iter(&mut self, count: usize) -> impl Iterator<Item = IndividualT> {
-        self.generate().into_iter()
+    fn generate_iter(&mut self, count: usize) -> IntoIter<IndividualT> {
+        self.generate(count).into_iter()
     }
 }
 


### PR DESCRIPTION
## Description

Add `generate_iter` method on `PopulationGenerator` trait.

Default implementation is provided, based on `generate` method -- I know that it makes little sense, because vector has to be allocated anyway, but I wanted to avoid refactoring of all operators for now. 

TODO: Refactor `PopulationGenerator` trait so that `generate` method is based on `generate_iter`.

## Linked issues

#403

