### PR TITLE
feat(ga): implement `with_probes` for `AggregatedProbe`

### DIFF
--- a/src/ga/probe/aggregated_probe.rs
+++ b/src/ga/probe/aggregated_probe.rs
@@ -14,6 +14,21 @@ impl<IndividualT: IndividualTrait> AggregatedProbe<IndividualT> {
         Self { probes: Vec::new() }
     }
 
+    /// Returns new instance of [AggregatedProbe] initialized
+    /// with given probes.
+    ///
+    /// ### Arguments
+    ///
+    /// * `probes` - Iterable with probes
+    pub fn with_probes<ProbeList>(probes: ProbeList) -> Self
+    where
+        ProbeList: IntoIterator<Item = Box<dyn Probe<IndividualT>>>,
+    {
+        Self {
+            probes: Vec::from_iter(probes),
+        }
+    }
+
     /// Add probe to list
     ///
     /// **Note**: Probes will be called in order they were added


### PR DESCRIPTION
## Description

Such method simplifies creation of `AggregatedProbe`

## Linked issues

Closes #408

## Important implementation details

Currently each element in the passed array must be of the `Box` type.

