### PR TITLE
feat(ga): make `ThreadRng` default generator type for all GA operators

### DIFF
--- a/src/ga/operators/crossover.rs
+++ b/src/ga/operators/crossover.rs
@@ -99,7 +99,7 @@ where
 /// Its mechanism is analoguous to [SinglePoint].
 ///
 /// Degenerate case when both cutpoints are in the same place or at position 0 or last can occur.
-pub struct TwoPoint<R: Rng> {
+pub struct TwoPoint<R: Rng = ThreadRng> {
     rng: R,
 }
 
@@ -185,7 +185,7 @@ where
 /// It works analogously to [SinglePoint] or [TwoPoint]. One important difference is that
 /// all cutpoints are distinct, thus single or two point crossover with guarantee of distinct cutpoints
 /// can be achieved.
-pub struct MultiPoint<R: Rng> {
+pub struct MultiPoint<R: Rng = ThreadRng> {
     cut_points_no: usize,
     rng: R,
 }
@@ -442,7 +442,7 @@ where
 /// Ch : 5 <b>4 1 3</b> 2
 ///
 /// Degenerated case when substring has length equal to genome length can occur.
-pub struct OrderedCrossover<R: Rng> {
+pub struct OrderedCrossover<R: Rng = ThreadRng> {
     rng: R,
 }
 
@@ -567,7 +567,7 @@ where
 /// Ch         : <i> 2 4 </i> <b> 5 </b> <i> 1<i/> <b> 3</b>
 ///
 /// Degenerated case when all genes are taken from the same parent.
-pub struct Ppx<R: Rng> {
+pub struct Ppx<R: Rng = ThreadRng> {
     rng: R,
     distribution: rand::distributions::Standard,
 }
@@ -699,7 +699,7 @@ where
 ///
 /// Degenerated case when substring has length equal to genome length can occur.
 ///
-pub struct Pmx<R: Rng> {
+pub struct Pmx<R: Rng = ThreadRng> {
     rng: R,
 }
 
@@ -849,7 +849,7 @@ where
 /// Lastly childs chromosomes are de-shuffled.
 ///
 /// Degenerated case when cutpoint is selected at index 0 or last can occur.
-pub struct Shuffle<R: Rng> {
+pub struct Shuffle<R: Rng = ThreadRng> {
     rng: R,
 }
 

--- a/src/ga/operators/mutation.rs
+++ b/src/ga/operators/mutation.rs
@@ -44,7 +44,7 @@ impl<IndividualT: IndividualTrait> MutationOperator<IndividualT> for Identity {
 /// This struct implements [MutationOperator] trait and can be used with GA
 ///
 /// Genes are muatated by flipping the value - `1` becomes `0` and vice versa
-pub struct FlipBit<R: Rng> {
+pub struct FlipBit<R: Rng = ThreadRng> {
     rng: R,
 }
 
@@ -94,7 +94,7 @@ where
 /// This struct implements [MutationOperator] trait and can be used with GA
 ///
 /// If a gene is to be muatated, a new locus is randomly choosen and gene values are interchanged
-pub struct Interchange<R: Rng> {
+pub struct Interchange<R: Rng = ThreadRng> {
     rng: R,
 }
 
@@ -204,19 +204,19 @@ where
 ///
 /// Two random locations are chosen marking out a segment of chromosome.
 /// Genes from this segment are then rotated around the segment's middle point.
-pub struct Inversion<R: Rng, GeneT: Copy> {
+pub struct Inversion<GeneT: Copy, R: Rng = ThreadRng> {
     rng: R,
     _marker: PhantomData<GeneT>,
 }
 
-impl<GeneT: Copy> Inversion<ThreadRng, GeneT> {
+impl<GeneT: Copy> Inversion<GeneT, ThreadRng> {
     /// Returns new instance of [Inversion] mutation operator with default RNG
     pub fn new() -> Self {
         Self::with_rng(rand::thread_rng())
     }
 }
 
-impl<R: Rng, GeneT: Copy> Inversion<R, GeneT> {
+impl<R: Rng, GeneT: Copy> Inversion<GeneT, R> {
     /// Returns new instance of [Inversion] mutation operator with custom RNG
     pub fn with_rng(rng: R) -> Self {
         Self {
@@ -226,7 +226,7 @@ impl<R: Rng, GeneT: Copy> Inversion<R, GeneT> {
     }
 }
 
-impl<IndividualT: IndividualTrait, GeneT: Copy, R: Rng> MutationOperator<IndividualT> for Inversion<R, GeneT>
+impl<IndividualT: IndividualTrait, GeneT: Copy, R: Rng> MutationOperator<IndividualT> for Inversion<GeneT, R>
 where
     IndividualT::ChromosomeT: Len + AsMut<[GeneT]>,
 {

--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -49,7 +49,7 @@ pub trait SelectionOperator<IndividualT: IndividualTrait> {
 ///
 /// Individuals are selected with probability proportional to their fitness value. More specifically:
 /// probability of selecting chromosome `C` from population `P` is `fitness(C)` / `sum_of_fitness_in_whole_population`.
-pub struct RouletteWheel<R: Rng> {
+pub struct RouletteWheel<R: Rng = ThreadRng> {
     rng: R,
 }
 
@@ -125,7 +125,7 @@ where
 /// Individuals are selected with uniform probability.
 ///
 /// **Note**: The same individual *can not* be selected mutiple times.
-pub struct Random<R: Rng> {
+pub struct Random<R: Rng = ThreadRng> {
     rng: R,
 }
 
@@ -248,7 +248,7 @@ where
 /// 4. Repeat 1-3 necessary number of times to create mating pool of demanded size
 ///
 /// **Note**: The same individual can be selected multiple times
-pub struct RankR<R: Rng> {
+pub struct RankR<R: Rng = ThreadRng> {
     r: f64,
     rng: R,
 }
@@ -425,7 +425,7 @@ impl<IndividualT: IndividualTrait, R: Rng> SelectionOperator<IndividualT> for To
 /// 3. Iterate over the pointers and select the individuals they point to
 ///
 /// See the source code for implemenation details
-pub struct StochasticUniversalSampling<R: Rng> {
+pub struct StochasticUniversalSampling<R: Rng = ThreadRng> {
     rng: R,
 }
 


### PR DESCRIPTION
## Description

Make `ThreadRng` default RNG type for all GA operators.

## Linked issues

Closes #362
