### PR TITLE
fix(ecdatakit): print empty values in marker line

### DIFF
--- a/examples/jssp/problem/probe.rs
+++ b/examples/jssp/problem/probe.rs
@@ -34,7 +34,7 @@ impl Probe<JsspIndividual> for JsspProbe {
         // This is a marker record for ECDataKit. Since it looks like
         // polars.DataFrame.read_csv deduces number of columns from the first encoutered
         // record it leads to crashes when longer records are encountered deeper in the file.
-        info!(target: "csv", "event,col_1,col_2,col_3,col_4,col_5,col_6,col_7");
+        info!(target: "csv", "event,,,,,,,");
     }
 
     fn on_initial_population_created(


### PR DESCRIPTION
## Description

When strings were specifed polars infered `str` as data type for each column. 

