### PR TITLE
chore(jssp): disable population diversity estimation

### DIFF
--- a/examples/jssp/problem/probe.rs
+++ b/examples/jssp/problem/probe.rs
@@ -11,6 +11,8 @@ impl JsspProbe {
         Self {}
     }
 
+    // TODO: This has either been not working as expected or the solver runs so bad.
+    // TODO: Verify whether the diversity is better on other problems
     fn estimate_pop_diversity(population: &[JsspIndividual]) -> f64 {
         population
             .iter()
@@ -42,7 +44,9 @@ impl Probe<JsspIndividual> for JsspProbe {
         metadata: &ecrs::ga::GAMetadata,
         population: &[JsspIndividual],
     ) {
-        let diversity = JsspProbe::estimate_pop_diversity(population);
+        // TODO: As this metric is useless right now I'm disabling it temporarily
+        // let diversity = JsspProbe::estimate_pop_diversity(population);
+        let diversity = 0.0;
         info!(target: "csv", "diversity,0,0,{},{diversity}\npopgentime,{}", population.len(), metadata.pop_gen_dur.unwrap().as_millis());
     }
 
@@ -57,7 +61,9 @@ impl Probe<JsspIndividual> for JsspProbe {
     }
 
     fn on_new_generation(&mut self, metadata: &ecrs::ga::GAMetadata, generation: &[JsspIndividual]) {
-        let diversity = JsspProbe::estimate_pop_diversity(generation);
+        // TODO: As this metric is useless right now I'm disabling it temporarily
+        // let diversity = JsspProbe::estimate_pop_diversity(generation);
+        let diversity = 0.0;
         info!(
             target: "csv",
             "diversity,{},{},{},{diversity}",


### PR DESCRIPTION
<!-- If applicable - remember to add the PR to the EA Rust project (ONLY IF THERE IS NO LINKED ISSUE) -->

## Description

Right now this mechanism is either not working or the solver is really bad. 
This needs to be tested, however using this right now is pointless.

