### PR TITLE
refact(jssp): store all run output in single directory instead of single file

### DIFF
--- a/examples/jssp/cli.rs
+++ b/examples/jssp/cli.rs
@@ -10,8 +10,8 @@ pub struct Args {
     pub input_file: PathBuf,
 
     /// Output file name
-    #[arg(short = 'o', long = "output-file")]
-    pub output_file: PathBuf,
+    #[arg(short = 'o', long = "output-dir")]
+    pub output_dir: PathBuf,
 }
 
 fn validate_args(args: &Args) -> Result<(), String> {

--- a/examples/jssp/logging.rs
+++ b/examples/jssp/logging.rs
@@ -47,7 +47,6 @@ pub fn init_logging(log_files: &HashMap<String, PathBuf>) -> Result<log4rs::Hand
                 .build(log::LevelFilter::Trace),
         )
         .unwrap();
-    // .appender(FileAppender::builder().encoder(Box::new(PatternEncoder::new(&csv_log_pattern))).build("log.txt"))
 
     log4rs::init_config(config)
 }

--- a/examples/jssp/main.rs
+++ b/examples/jssp/main.rs
@@ -58,7 +58,8 @@ fn run_with_ecrs(instance: JsspInstance, _args: Args) {
 
 fn run() {
     let args = cli::parse_args();
-
+    
+    util::assert_dir_exists(args.output_dir.as_ref());
     let event_map = util::create_event_map(args.output_dir.as_ref());
     if let Err(err) = logging::init_logging(&event_map) {
         panic!("Logger initialization failed with error: {err}");

--- a/examples/jssp/main.rs
+++ b/examples/jssp/main.rs
@@ -59,7 +59,8 @@ fn run_with_ecrs(instance: JsspInstance, _args: Args) {
 fn run() {
     let args = cli::parse_args();
 
-    if let Err(err) = logging::init_logging(Some(args.output_file.as_path())) {
+    let event_map = util::create_event_map(args.output_dir.as_ref());
+    if let Err(err) = logging::init_logging(&event_map) {
         panic!("Logger initialization failed with error: {err}");
     }
 

--- a/examples/jssp/problem/probe.rs
+++ b/examples/jssp/problem/probe.rs
@@ -33,10 +33,12 @@ impl Probe<JsspIndividual> for JsspProbe {
 
     #[inline]
     fn on_start(&mut self, _metadata: &ecrs::ga::GAMetadata) {
-        // This is a marker record for ECDataKit. Since it looks like
-        // polars.DataFrame.read_csv deduces number of columns from the first encoutered
-        // record it leads to crashes when longer records are encountered deeper in the file.
-        info!(target: "csv", "event,,,,,,,");
+        // Writing csv header to each file
+        info!(target: "diversity", "event_name,generation,total_duration,population_size,diversity");
+        info!(target: "popgentime", "event_name,time");
+        info!(target: "newbest", "event_name,generation,total_duration,fitness");
+        info!(target: "bestingen", "event_name,generation,total_duration,fitness");
+        info!(target: "iterinfo", "event_name,eval_time,sel_time,cross_time,mut_time,repl_time,iter_time");
     }
 
     fn on_initial_population_created(

--- a/examples/jssp/problem/probe.rs
+++ b/examples/jssp/problem/probe.rs
@@ -47,12 +47,13 @@ impl Probe<JsspIndividual> for JsspProbe {
         // TODO: As this metric is useless right now I'm disabling it temporarily
         // let diversity = JsspProbe::estimate_pop_diversity(population);
         let diversity = 0.0;
-        info!(target: "csv", "diversity,0,0,{},{diversity}\npopgentime,{}", population.len(), metadata.pop_gen_dur.unwrap().as_millis());
+        info!(target: "diversity", "diversity,0,0,{},{diversity}", population.len());
+        info!(target: "popgentime", "popgentime,{}", metadata.pop_gen_dur.unwrap().as_millis());
     }
 
     fn on_new_best(&mut self, metadata: &ecrs::ga::GAMetadata, individual: &JsspIndividual) {
         info!(
-            target: "csv",
+            target: "newbest",
             "newbest,{},{},{}",
             metadata.generation,
             metadata.total_dur.unwrap().as_millis(),
@@ -65,7 +66,7 @@ impl Probe<JsspIndividual> for JsspProbe {
         // let diversity = JsspProbe::estimate_pop_diversity(generation);
         let diversity = 0.0;
         info!(
-            target: "csv",
+            target: "diversity",
             "diversity,{},{},{},{diversity}",
             metadata.generation,
             metadata.total_dur.unwrap().as_millis(),
@@ -75,7 +76,7 @@ impl Probe<JsspIndividual> for JsspProbe {
 
     fn on_best_fit_in_generation(&mut self, metadata: &ecrs::ga::GAMetadata, individual: &JsspIndividual) {
         info!(
-            target: "csv",
+            target: "bestingen",
             "bestingen,{},{},{}",
             metadata.generation,
             metadata.total_dur.unwrap().as_millis(),
@@ -89,7 +90,7 @@ impl Probe<JsspIndividual> for JsspProbe {
 
     #[inline]
     fn on_iteration_end(&mut self, metadata: &ecrs::ga::GAMetadata) {
-        info!(target: "csv", "iterinfo,{},{},{},{},{},{},{}",
+        info!(target: "iterinfo", "iterinfo,{},{},{},{},{},{},{}",
             metadata.generation,
             metadata.pop_eval_dur.unwrap().as_millis(),
             metadata.selection_dur.unwrap().as_millis(),

--- a/examples/jssp/util.rs
+++ b/examples/jssp/util.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use std::{collections::HashSet, fmt::Display};
+use std::{collections::{HashSet, HashMap, hash_map}, fmt::Display, path::{PathBuf, Path}};
 
 pub fn print_hash_set<T: Display>(set: &HashSet<T>) {
     for elem in set {
@@ -14,4 +14,15 @@ pub fn print_slice<T: Display>(slc: &[T]) {
         print!("{elem}, ");
     }
     println!();
+}
+
+#[inline]
+pub fn create_event_map(base_dir: &Path) -> HashMap<String, PathBuf> {
+    HashMap::from([
+        ("diversity".to_owned(), base_dir.join("event_diversity.csv")),
+        ("newbest".to_owned(), base_dir.join("event_newbest.csv")),
+        ("bestingen".to_owned(), base_dir.join("event_bestingen.csv")),
+        ("popgentime".to_owned(), base_dir.join("event_popgentime.csv")),
+        ("iterinfo".to_owned(), base_dir.join("event_iterinfo.csv"))
+    ])
 }

--- a/examples/jssp/util.rs
+++ b/examples/jssp/util.rs
@@ -26,3 +26,14 @@ pub fn create_event_map(base_dir: &Path) -> HashMap<String, PathBuf> {
         ("iterinfo".to_owned(), base_dir.join("event_iterinfo.csv"))
     ])
 }
+
+pub fn assert_dir_exists(dir: &Path) {
+    if dir.is_dir() {
+        return;
+    }
+
+    match std::fs::create_dir_all(dir) {
+        Ok(()) => return,
+        Err(err) => panic!("Failed to create outuput directory with error {err}"),
+    };
+}


### PR DESCRIPTION

## Description

Multiple output files are now produced. Description can be found in ECDK docs.

