### PR TITLE
feat(jssp): guarantee operation predecessors order

### DIFF
--- a/examples/jssp/main.rs
+++ b/examples/jssp/main.rs
@@ -40,6 +40,12 @@ fn run_with_ecrs(instance: JsspInstance, _args: Args) {
             StdoutProbe::new(),
         ));
 
+    // Only for debugging purposes. TODO: Remove it
+    let population_provider = JsspPopProvider::new(instance.clone());
+    for op in population_provider.operations.iter() {
+        info!("{op:?}");
+    }
+
     let mut solver = ga::Builder::new()
         .set_selection_operator(selection::Rank::new())
         .set_crossover_operator(JsspCrossover::new())
@@ -67,11 +73,12 @@ fn run() {
 
     // Existance of input file is asserted during cli args parsing
     let instance = JsspInstance::try_from(&args.input_file).unwrap();
-    for job in instance.jobs.iter() {
-        for op in job {
-            info!("{op:?}");
-        }
-    }
+    // for job in instance.jobs.iter() {
+    //     for op in job {
+    //         info!("{op:?}");
+    //     }
+    //     info!("\n")
+    // }
     run_with_ecrs(instance, args)
 }
 

--- a/examples/jssp/problem.rs
+++ b/examples/jssp/problem.rs
@@ -89,7 +89,7 @@ impl Operation {
             edges_out: Vec::new(),
             machine_pred: None,
             critical_path_edge: None,
-            critical_distance: usize::MIN,
+            critical_distance: usize::MIN, // TODO: Should MIN be used here?
         }
     }
 

--- a/examples/jssp/problem/population.rs
+++ b/examples/jssp/problem/population.rs
@@ -10,7 +10,8 @@ use super::{individual::JsspIndividual, Edge, EdgeKind, JsspInstance, Machine, O
 
 pub struct JsspPopProvider {
     instance: JsspInstance,
-    operations: Vec<Operation>,
+    // This is public for debugging purposes
+    pub operations: Vec<Operation>,
 }
 
 impl JsspPopProvider {
@@ -28,7 +29,9 @@ impl JsspPopProvider {
             job.iter_mut().for_each(|op| {
                 op.id += 1;
                 op.preds.iter_mut().for_each(|pred_id| *pred_id += 1);
-                op.preds.push(0);
+                // We want the predecessors to be in asceding order. I rely on this behaviour in
+                // the JSSP solver later on. Do not change it w/o modyfing the algorithm.
+                op.preds.insert(0, 0);
                 op.edges_out.push(Edge {
                     neigh_id: op.id + 1,
                     kind: EdgeKind::JobSucc,


### PR DESCRIPTION
## Description

Operation zero is now inserted to the begining of the predecessor list.

I've not found any other places in codebase where predecessors are modified ==> the order should be guaranteed.

The order is ascending.

This will allow for few planned preformance optimizations
