### PR TITLE
fix: add important comment and update `total_dur` just before `on_end` callback

### DIFF
--- a/src/ga.rs
+++ b/src/ga.rs
@@ -176,6 +176,10 @@ where
 pub struct GAMetadata {
     pub generation: usize,
     pub start_time: Option<std::time::Instant>,
+
+    /// This field can not be relied upon. It is updated only in the begining
+    /// of each generation (iteration) & in the very end, just before `on_end`
+    /// probe callback. To get more accurate timing please use `start_time.elapsed()`.
     pub total_dur: Option<std::time::Duration>,
     pub pop_gen_dur: Option<std::time::Duration>,
     pub pop_eval_dur: Option<std::time::Duration>,
@@ -374,6 +378,7 @@ where
             }
         }
 
+        self.metadata.total_dur = Some(self.metadata.start_time.unwrap().elapsed());
         self.config
             .probe
             .on_end(&self.metadata, &population, &best_individual_all_time);


### PR DESCRIPTION
<!-- If applicable - remember to add the PR to the EA Rust project (ONLY IF THERE IS NO LINKED ISSUE) -->

## Description

Decided not to update `total_dur` before each hook call **for now**, to avoid vastly increasing number of syscalls.
This, however should be reconsidered in the future.

Added important comment to **slightly** decrease likelihood of future misuse of this field.

## Linked issues <!-- Please use "Resolves #<issue_no> syntax in case this PR should be linked to an issue -->

Closes #471

## Important implementation details <!-- if any, optional section -->

