### PR TITLE
refact: move `selection_rate` & `mutation_rate` out from `GAParams` to operators

### DIFF
--- a/coco/src/main.rs
+++ b/coco/src/main.rs
@@ -120,7 +120,7 @@ fn ecrs_ga_search(problem: &mut Problem, _max_budget: usize, _random_generator: 
     ))
     .set_selection_operator(selection::Tournament::new(0.2))
     .set_crossover_operator(crossover::Uniform::new())
-    .set_mutation_operator(mutation::Reversing::new())
+    .set_mutation_operator(mutation::Reversing::new(0.05))
     .set_replacement_operator(replacement::WeakParent::new())
     .build();
 

--- a/src/ga.rs
+++ b/src/ga.rs
@@ -143,8 +143,8 @@ use self::{
 };
 
 pub struct GAParams {
-    pub selection_rate: f64,
-    pub mutation_rate: f64,
+    // pub selection_rate: f64,
+    // pub mutation_rate: f64,
     pub population_size: usize,
     pub generation_limit: usize,
     pub max_duration: std::time::Duration,
@@ -322,11 +322,9 @@ where
             self.metadata.crossover_dur = Some(self.timer.elapsed());
 
             self.timer.start();
-            children.iter_mut().for_each(|child| {
-                self.config
-                    .mutation_operator
-                    .apply(&self.metadata, child, self.config.params.mutation_rate)
-            });
+            children
+                .iter_mut()
+                .for_each(|child| self.config.mutation_operator.apply(&self.metadata, child));
             self.metadata.mutation_dur = Some(self.timer.elapsed());
 
             if self.config.replacement_operator.requires_children_fitness() {

--- a/src/ga/builder.rs
+++ b/src/ga/builder.rs
@@ -64,8 +64,6 @@ impl Error for ConfigError {}
 // don't have to write it by hand...
 #[derive(Debug, Clone)]
 pub struct GAParamsOpt {
-    pub selection_rate: Option<f64>,
-    pub mutation_rate: Option<f64>,
     pub population_size: Option<usize>,
     pub generation_limit: Option<usize>,
     pub max_duration: Option<std::time::Duration>,
@@ -75,8 +73,6 @@ impl GAParamsOpt {
     /// Returns new instance of [GAParamsOpt] struct. All fields are `None` initially.
     pub fn new() -> Self {
         Self {
-            selection_rate: None,
-            mutation_rate: None,
             population_size: None,
             generation_limit: None,
             max_duration: None,
@@ -85,8 +81,6 @@ impl GAParamsOpt {
 
     /// Sets all `None` values to values form `other`
     pub fn fill_from(&mut self, other: &GAParams) {
-        self.selection_rate.get_or_insert(other.selection_rate);
-        self.mutation_rate.get_or_insert(other.mutation_rate);
         self.population_size.get_or_insert(other.population_size);
         self.generation_limit.get_or_insert(other.generation_limit);
         self.max_duration.get_or_insert(other.max_duration);
@@ -97,14 +91,6 @@ impl TryFrom<GAParamsOpt> for GAParams {
     type Error = ConfigError;
 
     fn try_from(params_opt: GAParamsOpt) -> Result<Self, Self::Error> {
-        let Some(selection_rate) = params_opt.selection_rate else {
-            return Err(ConfigError::MissingParam("Unspecified selection rate".to_owned()));
-        };
-
-        let Some(mutation_rate) = params_opt.mutation_rate else {
-            return Err(ConfigError::MissingParam("Unspecified mutation rate".to_owned()));
-        };
-
         let Some(population_size) = params_opt.population_size else {
             return Err(ConfigError::MissingParam(
                 "Unspecified population size".to_owned(),
@@ -122,8 +108,6 @@ impl TryFrom<GAParamsOpt> for GAParams {
         };
 
         Ok(GAParams {
-            selection_rate,
-            mutation_rate,
             population_size,
             generation_limit,
             max_duration,
@@ -313,8 +297,8 @@ impl Builder {
 /// some of the values.
 pub(crate) trait DefaultParams {
     const DEFAULT_PARAMS: GAParams = GAParams {
-        selection_rate: 1.0,
-        mutation_rate: 0.05,
+        // selection_rate: 1.0,
+        // mutation_rate: 0.05,
         population_size: 100,
         generation_limit: usize::MAX,
         max_duration: std::time::Duration::MAX,
@@ -340,8 +324,8 @@ mod test {
     #[test]
     fn new_param_opt_is_empty() {
         let params = GAParamsOpt::new();
-        assert!(params.selection_rate.is_none());
-        assert!(params.mutation_rate.is_none());
+        // assert!(params.selection_rate.is_none());
+        // assert!(params.mutation_rate.is_none());
         assert!(params.population_size.is_none());
         assert!(params.generation_limit.is_none());
         assert!(params.max_duration.is_none());
@@ -350,12 +334,9 @@ mod test {
     #[test]
     fn param_opt_fills_correctly() {
         let mut params_opt = GAParamsOpt::new();
-        params_opt.selection_rate = Some(0.5);
         params_opt.generation_limit = Some(100);
 
         let params = GAParams {
-            selection_rate: 1.0,
-            mutation_rate: 1.0,
             population_size: 100,
             generation_limit: 200,
             max_duration: std::time::Duration::from_secs(1),
@@ -363,8 +344,6 @@ mod test {
 
         params_opt.fill_from(&params);
 
-        assert!(params_opt.selection_rate.is_some() && params_opt.selection_rate.unwrap() == 0.5);
-        assert!(params_opt.mutation_rate.is_some() && params_opt.mutation_rate.unwrap() == 1.0);
         assert!(params_opt.population_size.is_some() && params_opt.population_size.unwrap() == 100);
         assert!(params_opt.generation_limit.is_some() && params_opt.generation_limit.unwrap() == 100);
         assert!(
@@ -376,12 +355,6 @@ mod test {
     #[test]
     fn conversion_works_as_expected() {
         let mut params_opt = GAParamsOpt::new();
-
-        params_opt.selection_rate = Some(1.0);
-        assert!(convert_gaparamsopt_to_ga_params(params_opt.clone()).is_err());
-
-        params_opt.mutation_rate = Some(0.0);
-        assert!(convert_gaparamsopt_to_ga_params(params_opt.clone()).is_err());
 
         params_opt.population_size = Some(200);
         assert!(convert_gaparamsopt_to_ga_params(params_opt.clone()).is_err());

--- a/src/ga/builder/bitstring.rs
+++ b/src/ga/builder/bitstring.rs
@@ -145,7 +145,9 @@ impl<F: Fitness<BitStringIndividual>> BitStringBuilder<F> {
         self.config
             .crossover_operator
             .get_or_insert_with(SinglePoint::new);
-        self.config.mutation_operator.get_or_insert_with(|| FlipBit::new(0.05));
+        self.config
+            .mutation_operator
+            .get_or_insert_with(|| FlipBit::new(0.05));
         self.config
             .selection_operator
             .get_or_insert_with(|| Tournament::new(0.2));

--- a/src/ga/builder/bitstring.rs
+++ b/src/ga/builder/bitstring.rs
@@ -57,28 +57,6 @@ impl<F: Fitness<BitStringIndividual>> BitStringBuilder<F> {
         }
     }
 
-    /// Sets selection rate
-    ///
-    /// ## Arguments
-    ///
-    /// * `selection_rate` - Selection rate; must be in [0, 1] interval
-    pub fn set_selection_rate(mut self, selection_rate: f64) -> Self {
-        assert!((0f64..=1f64).contains(&selection_rate));
-        self.config.params.selection_rate = Some(selection_rate);
-        self
-    }
-
-    /// Sets mutation rate
-    ///
-    /// ## Arguments
-    ///
-    /// * `mutation_rate` - Mutation rate; must be in [0, 1] interval
-    pub fn set_mutation_rate(mut self, mutation_rate: f64) -> Self {
-        assert!((0.0..=1.0).contains(&mutation_rate));
-        self.config.params.mutation_rate = Some(mutation_rate);
-        self
-    }
-
     /// Sets max duration. If exceeded, the algorithm halts.
     ///
     /// ## Arguments
@@ -167,7 +145,7 @@ impl<F: Fitness<BitStringIndividual>> BitStringBuilder<F> {
         self.config
             .crossover_operator
             .get_or_insert_with(SinglePoint::new);
-        self.config.mutation_operator.get_or_insert_with(FlipBit::new);
+        self.config.mutation_operator.get_or_insert_with(|| FlipBit::new(0.05));
         self.config
             .selection_operator
             .get_or_insert_with(|| Tournament::new(0.2));

--- a/src/ga/builder/generic.rs
+++ b/src/ga/builder/generic.rs
@@ -75,36 +75,6 @@ where
         }
     }
 
-    /// Sets selection rate
-    ///
-    /// ## Arguments
-    ///
-    /// * `selection_rate` - Selection rate; must be in [0, 1] interval
-    ///
-    /// ## Panics
-    ///
-    /// If the `selection_rate` param has invalid value.
-    pub fn set_selection_rate(mut self, selection_rate: f64) -> Self {
-        assert!((0f64..=1f64).contains(&selection_rate));
-        self.config.params.selection_rate = Some(selection_rate);
-        self
-    }
-
-    /// Sets mutation rate
-    ///
-    /// ## Arguments
-    ///
-    /// * `mutation_rate` - Mutation rate; must be in [0, 1] interval
-    ///
-    /// ## Panics
-    ///
-    /// If the parameter has invalid value.
-    pub fn set_mutation_rate(mut self, mutation_rate: f64) -> Self {
-        assert!((0.0..=1.0).contains(&mutation_rate));
-        self.config.params.mutation_rate = Some(mutation_rate);
-        self
-    }
-
     /// Sets max duration. If exceeded, the algorithm halts.
     ///
     /// ## Arguments

--- a/src/ga/builder/realvalued.rs
+++ b/src/ga/builder/realvalued.rs
@@ -144,7 +144,9 @@ impl<F: Fitness<RealValueIndividual>> RealValuedBuilder<F> {
         self.config
             .crossover_operator
             .get_or_insert_with(SinglePoint::new);
-        self.config.mutation_operator.get_or_insert_with(|| Interchange::new(0.05));
+        self.config
+            .mutation_operator
+            .get_or_insert_with(|| Interchange::new(0.05));
         self.config
             .selection_operator
             .get_or_insert_with(|| Tournament::new(0.2));

--- a/src/ga/builder/realvalued.rs
+++ b/src/ga/builder/realvalued.rs
@@ -56,28 +56,6 @@ impl<F: Fitness<RealValueIndividual>> RealValuedBuilder<F> {
         }
     }
 
-    /// Sets selection rate
-    ///
-    /// ## Arguments
-    ///
-    /// * `selection_rate` - Selection rate; must be in [0, 1] interval
-    pub fn set_selection_rate(mut self, selection_rate: f64) -> Self {
-        debug_assert!((0f64..=1f64).contains(&selection_rate));
-        self.config.params.selection_rate = Some(selection_rate);
-        self
-    }
-
-    /// Sets mutation rate
-    ///
-    /// ## Arguments
-    ///
-    /// * `mutation_rate` - Mutation rate; must be in [0, 1] interval
-    pub fn set_mutation_rate(mut self, mutation_rate: f64) -> Self {
-        assert!((0.0..=1.0).contains(&mutation_rate));
-        self.config.params.mutation_rate = Some(mutation_rate);
-        self
-    }
-
     /// Sets max duration. If exceeded, the algorithm halts.
     ///
     /// ## Arguments
@@ -166,7 +144,7 @@ impl<F: Fitness<RealValueIndividual>> RealValuedBuilder<F> {
         self.config
             .crossover_operator
             .get_or_insert_with(SinglePoint::new);
-        self.config.mutation_operator.get_or_insert_with(Interchange::new);
+        self.config.mutation_operator.get_or_insert_with(|| Interchange::new(0.05));
         self.config
             .selection_operator
             .get_or_insert_with(|| Tournament::new(0.2));

--- a/src/ga/operators/mutation.rs
+++ b/src/ga/operators/mutation.rs
@@ -16,5 +16,5 @@ pub trait MutationOperator<IndividualT: IndividualTrait> {
     ///
     /// * `individual` - mutable reference to to-be-mutated individual
     /// * `mutation_rate` - probability of gene mutation
-    fn apply(&mut self, metadata: &GAMetadata, individual: &mut IndividualT, mutation_rate: f64);
+    fn apply(&mut self, metadata: &GAMetadata, individual: &mut IndividualT);
 }

--- a/src/ga/operators/mutation/impls.rs
+++ b/src/ga/operators/mutation/impls.rs
@@ -24,7 +24,7 @@ impl Identity {
 }
 
 impl<IndividualT: IndividualTrait> MutationOperator<IndividualT> for Identity {
-    fn apply(&mut self, _metadata: &GAMetadata, _individual: &mut IndividualT, _mutation_rate: f64) {}
+    fn apply(&mut self, _metadata: &GAMetadata, _individual: &mut IndividualT) {}
 }
 
 /// ### Flilp bit mutation operator
@@ -33,20 +33,21 @@ impl<IndividualT: IndividualTrait> MutationOperator<IndividualT> for Identity {
 ///
 /// Genes are muatated by flipping the value - `1` becomes `0` and vice versa
 pub struct FlipBit<R: Rng = ThreadRng> {
+    mutation_rate: f64,
     rng: R,
 }
 
 impl FlipBit<ThreadRng> {
     /// Returns new instance of [FlipBit] mutation operator with default RNG
-    pub fn new() -> Self {
-        Self::with_rng(rand::thread_rng())
+    pub fn new(mutation_rate: f64) -> Self {
+        Self::with_rng(mutation_rate, rand::thread_rng())
     }
 }
 
 impl<R: Rng> FlipBit<R> {
     /// Returns new instance of [FlipBit] mutation operator with custom RNG
-    pub fn with_rng(rng: R) -> Self {
-        Self { rng }
+    pub fn with_rng(mutation_rate: f64, rng: R) -> Self {
+        Self { mutation_rate, rng }
     }
 }
 
@@ -64,13 +65,13 @@ where
     ///
     /// * `individual` - mutable reference to to-be-mutated individual
     /// * `mutation_rate` - probability of gene mutation
-    fn apply(&mut self, _metadata: &GAMetadata, individual: &mut IndividualT, mutation_rate: f64) {
+    fn apply(&mut self, _metadata: &GAMetadata, individual: &mut IndividualT) {
         let distribution = rand::distributions::Uniform::from(0.0..1.0);
         let chromosome_ref = individual.chromosome_mut();
         let chromosome_len = chromosome_ref.len();
 
         for i in 0..chromosome_len {
-            if self.rng.sample(distribution) < mutation_rate {
+            if self.rng.sample(distribution) < self.mutation_rate {
                 chromosome_ref[i] = !chromosome_ref[i];
             }
         }
@@ -83,20 +84,21 @@ where
 ///
 /// If a gene is to be muatated, a new locus is randomly choosen and gene values are interchanged
 pub struct Interchange<R: Rng = ThreadRng> {
+    mutation_rate: f64,
     rng: R,
 }
 
 impl Interchange<ThreadRng> {
     /// Returns new instance of [Interchange] mutation operator with default RNG
-    pub fn new() -> Self {
-        Self::with_rng(rand::thread_rng())
+    pub fn new(mutation_rate: f64) -> Self {
+        Self::with_rng(mutation_rate, rand::thread_rng())
     }
 }
 
 impl<R: Rng> Interchange<R> {
     /// Returns new instance of [Interchange] mutation operator with custom RNG
-    pub fn with_rng(rng: R) -> Self {
-        Self { rng }
+    pub fn with_rng(mutation_rate: f64, rng: R) -> Self {
+        Self { mutation_rate, rng }
     }
 }
 
@@ -115,7 +117,7 @@ where
     ///
     /// * `individual` - mutable reference to to-be-mutated individual
     /// * `mutation_rate` - probability of gene mutation
-    fn apply(&mut self, _metadata: &GAMetadata, individual: &mut IndividualT, mutation_rate: f64) {
+    fn apply(&mut self, _metadata: &GAMetadata, individual: &mut IndividualT) {
         let chromosome_ref = individual.chromosome_mut();
         let chromosome_len = chromosome_ref.len();
 
@@ -123,7 +125,7 @@ where
         let index_dist = rand::distributions::Uniform::from(0..chromosome_len);
 
         for i in 0..chromosome_len {
-            if self.rng.sample(dist) < mutation_rate {
+            if self.rng.sample(dist) < self.mutation_rate {
                 let rand_index = rand::thread_rng().sample(index_dist);
                 let gene = chromosome_ref[rand_index];
                 chromosome_ref[rand_index] = chromosome_ref[i];
@@ -139,20 +141,21 @@ where
 ///
 /// Random locus is selected and genes next to the selection position are reversed
 pub struct Reversing<R: Rng = ThreadRng> {
+    mutation_rate: f64,
     rng: R,
 }
 
 impl Reversing<ThreadRng> {
     /// Returns new instance of [Reversing] mutation operator with default RNG
-    pub fn new() -> Self {
-        Self::with_rng(rand::thread_rng())
+    pub fn new(mutation_rate: f64) -> Self {
+        Self::with_rng(mutation_rate, rand::thread_rng())
     }
 }
 
 impl<R: Rng> Reversing<R> {
     /// Returns new instance of [Reversing] mutation operator with custom RNG
-    pub fn with_rng(rng: R) -> Self {
-        Self { rng }
+    pub fn with_rng(mutation_rate: f64, rng: R) -> Self {
+        Self { mutation_rate, rng }
     }
 }
 
@@ -171,13 +174,13 @@ where
     ///
     /// * `individual` - mutable reference to to-be-mutated individual
     /// * `mutation_rate` - probability of gene mutation
-    fn apply(&mut self, _metadata: &GAMetadata, individual: &mut IndividualT, mutation_rate: f64) {
+    fn apply(&mut self, _metadata: &GAMetadata, individual: &mut IndividualT) {
         let dist = rand::distributions::Uniform::from(0.0..1.0);
         let chromosome_ref = individual.chromosome_mut();
         let chromosome_len = chromosome_ref.len();
 
         for i in 1..chromosome_len {
-            if self.rng.sample(dist) < mutation_rate {
+            if self.rng.sample(dist) < self.mutation_rate {
                 let gene = chromosome_ref[i];
                 chromosome_ref[i] = chromosome_ref[i - 1];
                 chromosome_ref[i - 1] = gene;
@@ -193,21 +196,23 @@ where
 /// Two random locations are chosen marking out a segment of chromosome.
 /// Genes from this segment are then rotated around the segment's middle point.
 pub struct Inversion<GeneT: Copy, R: Rng = ThreadRng> {
+    mutation_rate: f64,
     rng: R,
     _marker: PhantomData<GeneT>,
 }
 
 impl<GeneT: Copy> Inversion<GeneT, ThreadRng> {
     /// Returns new instance of [Inversion] mutation operator with default RNG
-    pub fn new() -> Self {
-        Self::with_rng(rand::thread_rng())
+    pub fn new(mutation_rate: f64) -> Self {
+        Self::with_rng(mutation_rate, rand::thread_rng())
     }
 }
 
 impl<R: Rng, GeneT: Copy> Inversion<GeneT, R> {
     /// Returns new instance of [Inversion] mutation operator with custom RNG
-    pub fn with_rng(rng: R) -> Self {
+    pub fn with_rng(mutation_rate: f64, rng: R) -> Self {
         Self {
+            mutation_rate,
             rng,
             _marker: PhantomData,
         }
@@ -227,12 +232,12 @@ where
     ///
     /// * `individual` - mutable reference to to-be-mutated individual
     /// * `mutation_rate` - probability of gene mutation
-    fn apply(&mut self, _metadata: &GAMetadata, individual: &mut IndividualT, mutation_rate: f64) {
+    fn apply(&mut self, _metadata: &GAMetadata, individual: &mut IndividualT) {
         let _marker: PhantomData<GeneT> = PhantomData;
 
         let r: f64 = self.rng.gen();
 
-        if r > mutation_rate {
+        if r > self.mutation_rate {
             return;
         }
 
@@ -270,7 +275,7 @@ mod tests {
 
         let mut identity_mutation = Identity;
 
-        identity_mutation.apply(&GAMetadata::default(), &mut individual, 1.);
+        identity_mutation.apply(&GAMetadata::default(), &mut individual);
 
         assert_eq!(chromosome, individual.chromosome);
     }
@@ -290,9 +295,9 @@ mod tests {
             fitness: f64::default(),
         };
 
-        let mut operator = FlipBit::new();
+        let mut operator = FlipBit::new(1.);
 
-        operator.apply(&GAMetadata::default(), &mut individual, 1.);
+        operator.apply(&GAMetadata::default(), &mut individual);
 
         for (actual, expected) in std::iter::zip(chromosome_clone, individual.chromosome()) {
             assert_eq!(actual, !*expected);
@@ -314,9 +319,9 @@ mod tests {
             fitness: f64::default(),
         };
 
-        let mut operator = FlipBit::new();
+        let mut operator = FlipBit::new(0.);
 
-        operator.apply(&GAMetadata::default(), &mut individual, 0.);
+        operator.apply(&GAMetadata::default(), &mut individual);
 
         for (actual, expected) in std::iter::zip(chromosome_clone, individual.chromosome()) {
             assert_eq!(actual, *expected);
@@ -338,9 +343,9 @@ mod tests {
             fitness: f64::default(),
         };
 
-        let mut operator = Interchange::new();
+        let mut operator = Interchange::new(1.);
 
-        operator.apply(&GAMetadata::default(), &mut individual, 1.);
+        operator.apply(&GAMetadata::default(), &mut individual);
         let changes = std::iter::zip(chromosome_clone, individual.chromosome())
             .filter(|p| p.0 != *p.1)
             .count();
@@ -362,9 +367,9 @@ mod tests {
             fitness: f64::default(),
         };
 
-        let mut operator = Interchange::new();
+        let mut operator = Interchange::new(0.);
 
-        operator.apply(&GAMetadata::default(), &mut individual, 0.);
+        operator.apply(&GAMetadata::default(), &mut individual);
 
         for (actual, expected) in std::iter::zip(chromosome_clone, individual.chromosome()) {
             assert_eq!(actual, *expected);
@@ -385,9 +390,9 @@ mod tests {
 
         let first_gene_value = individual.chromosome()[0];
 
-        let mut operator = Reversing::new();
+        let mut operator = Reversing::new(1.0);
 
-        operator.apply(&GAMetadata::default(), &mut individual, 1.0);
+        operator.apply(&GAMetadata::default(), &mut individual);
 
         assert_eq!(
             first_gene_value,


### PR DESCRIPTION
## Description

## Linked issues <!-- Please use "Resolves #<issue_no> syntax in case this PR should be linked to an issue -->

Closes #477
Closes https://github.com/kkafar/master-monorepo/issues/246

## Important implementation details <!-- if any, optional section -->

