### PR TITLE
refact!: rename `GAMetadata` -> `Metrics`

### DIFF
--- a/examples/jssp/main.rs
+++ b/examples/jssp/main.rs
@@ -14,7 +14,7 @@ use config::Config;
 use ecrs::ga::probe::{AggregatedProbe, ElapsedTime, PolicyDrivenProbe, ProbingPolicy};
 use ecrs::prelude::{crossover, ga, ops, replacement, selection};
 use ecrs::{
-    ga::{GAMetadata, Individual, StdoutProbe},
+    ga::{Metrics, Individual, StdoutProbe},
     prelude::{
         crossover::{CrossoverOperator, UniformParameterized},
         mutation::{self, Identity},

--- a/examples/jssp/main.rs
+++ b/examples/jssp/main.rs
@@ -14,7 +14,7 @@ use config::Config;
 use ecrs::ga::probe::{AggregatedProbe, ElapsedTime, PolicyDrivenProbe, ProbingPolicy};
 use ecrs::prelude::{crossover, ga, ops, replacement, selection};
 use ecrs::{
-    ga::{Metrics, Individual, StdoutProbe},
+    ga::{Individual, Metrics, StdoutProbe},
     prelude::{
         crossover::{CrossoverOperator, UniformParameterized},
         mutation::{self, Identity},

--- a/examples/jssp/problem/crossover.rs
+++ b/examples/jssp/problem/crossover.rs
@@ -20,7 +20,7 @@ impl JsspCrossover {
 
     fn apply_single(
         &mut self,
-        _metadata: &Metrics,
+        _metrics: &Metrics,
         parent_1: &JsspIndividual,
         parent_2: &JsspIndividual,
     ) -> (JsspIndividual, JsspIndividual) {
@@ -53,13 +53,13 @@ impl JsspCrossover {
 }
 
 impl CrossoverOperator<JsspIndividual> for JsspCrossover {
-    fn apply(&mut self, metadata: &Metrics, selected: &[&JsspIndividual]) -> Vec<JsspIndividual> {
+    fn apply(&mut self, metrics: &Metrics, selected: &[&JsspIndividual]) -> Vec<JsspIndividual> {
         assert!(selected.len() & 1 == 0);
 
         let mut output = Vec::with_capacity(selected.len());
 
         for parents in selected.chunks(2) {
-            let (child_1, child_2) = self.apply_single(metadata, parents[0], parents[1]);
+            let (child_1, child_2) = self.apply_single(metrics, parents[0], parents[1]);
             output.push(child_1);
             output.push(child_2);
         }
@@ -77,7 +77,7 @@ impl NoopCrossover {
 
     fn apply_single(
         &mut self,
-        _metadata: &Metrics,
+        _metrics: &Metrics,
         parent_1: &JsspIndividual,
         parent_2: &JsspIndividual,
     ) -> (JsspIndividual, JsspIndividual) {
@@ -86,13 +86,13 @@ impl NoopCrossover {
 }
 
 impl CrossoverOperator<JsspIndividual> for NoopCrossover {
-    fn apply(&mut self, metadata: &Metrics, selected: &[&JsspIndividual]) -> Vec<JsspIndividual> {
+    fn apply(&mut self, metrics: &Metrics, selected: &[&JsspIndividual]) -> Vec<JsspIndividual> {
         assert!(selected.len() & 1 == 0);
 
         let mut output = Vec::with_capacity(selected.len());
 
         for parents in selected.chunks(2) {
-            let (child_1, child_2) = self.apply_single(metadata, parents[0], parents[1]);
+            let (child_1, child_2) = self.apply_single(metrics, parents[0], parents[1]);
             output.push(child_1);
             output.push(child_2);
         }

--- a/examples/jssp/problem/crossover.rs
+++ b/examples/jssp/problem/crossover.rs
@@ -1,5 +1,5 @@
 use ecrs::{
-    ga::{individual::IndividualTrait, GAMetadata},
+    ga::{individual::IndividualTrait, Metrics},
     prelude::crossover::CrossoverOperator,
 };
 use push_trait::PushBack;
@@ -20,7 +20,7 @@ impl JsspCrossover {
 
     fn apply_single(
         &mut self,
-        _metadata: &GAMetadata,
+        _metadata: &Metrics,
         parent_1: &JsspIndividual,
         parent_2: &JsspIndividual,
     ) -> (JsspIndividual, JsspIndividual) {
@@ -53,7 +53,7 @@ impl JsspCrossover {
 }
 
 impl CrossoverOperator<JsspIndividual> for JsspCrossover {
-    fn apply(&mut self, metadata: &GAMetadata, selected: &[&JsspIndividual]) -> Vec<JsspIndividual> {
+    fn apply(&mut self, metadata: &Metrics, selected: &[&JsspIndividual]) -> Vec<JsspIndividual> {
         assert!(selected.len() & 1 == 0);
 
         let mut output = Vec::with_capacity(selected.len());
@@ -77,7 +77,7 @@ impl NoopCrossover {
 
     fn apply_single(
         &mut self,
-        _metadata: &GAMetadata,
+        _metadata: &Metrics,
         parent_1: &JsspIndividual,
         parent_2: &JsspIndividual,
     ) -> (JsspIndividual, JsspIndividual) {
@@ -86,7 +86,7 @@ impl NoopCrossover {
 }
 
 impl CrossoverOperator<JsspIndividual> for NoopCrossover {
-    fn apply(&mut self, metadata: &GAMetadata, selected: &[&JsspIndividual]) -> Vec<JsspIndividual> {
+    fn apply(&mut self, metadata: &Metrics, selected: &[&JsspIndividual]) -> Vec<JsspIndividual> {
         assert!(selected.len() & 1 == 0);
 
         let mut output = Vec::with_capacity(selected.len());

--- a/examples/jssp/problem/probe.rs
+++ b/examples/jssp/problem/probe.rs
@@ -84,7 +84,7 @@ impl Probe<JsspIndividual> for JsspProbe {
     // iterinfo,<generation>,<eval_time>,<sel_time>,<cross_time>,<mut_time>,<repl_time>,<iter_time>
 
     #[inline]
-    fn on_start(&mut self, _metadata: &ecrs::ga::GAMetadata) {
+    fn on_start(&mut self, _metadata: &ecrs::ga::Metrics) {
         // Writing csv header to each file
         info!(target: "popmetrics", "event_name,generation,total_duration,population_size,diversity,distance_avg");
         info!(target: "popgentime", "event_name,time");
@@ -95,7 +95,7 @@ impl Probe<JsspIndividual> for JsspProbe {
 
     fn on_initial_population_created(
         &mut self,
-        metadata: &ecrs::ga::GAMetadata,
+        metadata: &ecrs::ga::Metrics,
         population: &[JsspIndividual],
     ) {
         debug_assert_eq!(self.repeated.len(), 0);
@@ -109,7 +109,7 @@ impl Probe<JsspIndividual> for JsspProbe {
         info!(target: "popgentime", "popgentime,{}", metadata.pop_gen_dur.unwrap().as_millis());
     }
 
-    fn on_new_best(&mut self, metadata: &ecrs::ga::GAMetadata, individual: &JsspIndividual) {
+    fn on_new_best(&mut self, metadata: &ecrs::ga::Metrics, individual: &JsspIndividual) {
         info!(
             target: "newbest",
             "newbest,{},{},{}",
@@ -119,7 +119,7 @@ impl Probe<JsspIndividual> for JsspProbe {
         );
     }
 
-    fn on_new_generation(&mut self, metadata: &ecrs::ga::GAMetadata, generation: &[JsspIndividual]) {
+    fn on_new_generation(&mut self, metadata: &ecrs::ga::Metrics, generation: &[JsspIndividual]) {
         // TODO: As this metric is useless right now I'm disabling it temporarily
         // let diversity = self.estimate_pop_diversity(generation);
         let diversity = self.estimate_pop_diversity(generation);
@@ -133,7 +133,7 @@ impl Probe<JsspIndividual> for JsspProbe {
         );
     }
 
-    fn on_best_fit_in_generation(&mut self, metadata: &ecrs::ga::GAMetadata, individual: &JsspIndividual) {
+    fn on_best_fit_in_generation(&mut self, metadata: &ecrs::ga::Metrics, individual: &JsspIndividual) {
         info!(
             target: "bestingen",
             "bestingen,{},{},{}",
@@ -144,11 +144,11 @@ impl Probe<JsspIndividual> for JsspProbe {
     }
 
     #[inline]
-    fn on_iteration_start(&mut self, _metadata: &ecrs::ga::GAMetadata) { /* defaults to noop */
+    fn on_iteration_start(&mut self, _metadata: &ecrs::ga::Metrics) { /* defaults to noop */
     }
 
     #[inline]
-    fn on_iteration_end(&mut self, metadata: &ecrs::ga::GAMetadata) {
+    fn on_iteration_end(&mut self, metadata: &ecrs::ga::Metrics) {
         info!(target: "iterinfo", "iterinfo,{},{},{},{},{},{},{}",
             metadata.generation,
             metadata.pop_eval_dur.unwrap().as_millis(),
@@ -163,7 +163,7 @@ impl Probe<JsspIndividual> for JsspProbe {
     #[inline]
     fn on_end(
         &mut self,
-        metadata: &ecrs::ga::GAMetadata,
+        metadata: &ecrs::ga::Metrics,
         _population: &[JsspIndividual],
         best_individual: &JsspIndividual,
     ) {

--- a/examples/jssp/problem/probe.rs
+++ b/examples/jssp/problem/probe.rs
@@ -84,7 +84,7 @@ impl Probe<JsspIndividual> for JsspProbe {
     // iterinfo,<generation>,<eval_time>,<sel_time>,<cross_time>,<mut_time>,<repl_time>,<iter_time>
 
     #[inline]
-    fn on_start(&mut self, _metadata: &ecrs::ga::Metrics) {
+    fn on_start(&mut self, _metrics: &ecrs::ga::Metrics) {
         // Writing csv header to each file
         info!(target: "popmetrics", "event_name,generation,total_duration,population_size,diversity,distance_avg");
         info!(target: "popgentime", "event_name,time");
@@ -93,7 +93,7 @@ impl Probe<JsspIndividual> for JsspProbe {
         info!(target: "iterinfo", "event_name,generation,eval_time,sel_time,cross_time,mut_time,repl_time,iter_time");
     }
 
-    fn on_initial_population_created(&mut self, metadata: &ecrs::ga::Metrics, population: &[JsspIndividual]) {
+    fn on_initial_population_created(&mut self, metrics: &ecrs::ga::Metrics, population: &[JsspIndividual]) {
         debug_assert_eq!(self.repeated.len(), 0);
         self.repeated.resize(population.len(), false);
 
@@ -102,20 +102,20 @@ impl Probe<JsspIndividual> for JsspProbe {
         let diversity = self.estimate_pop_diversity(population);
         let distance_avg = self.estimate_avg_distance(population);
         info!(target: "popmetrics", "diversity,0,0,{},{diversity},{distance_avg}", population.len());
-        info!(target: "popgentime", "popgentime,{}", metadata.pop_gen_dur.unwrap().as_millis());
+        info!(target: "popgentime", "popgentime,{}", metrics.pop_gen_dur.unwrap().as_millis());
     }
 
-    fn on_new_best(&mut self, metadata: &ecrs::ga::Metrics, individual: &JsspIndividual) {
+    fn on_new_best(&mut self, metrics: &ecrs::ga::Metrics, individual: &JsspIndividual) {
         info!(
             target: "newbest",
             "newbest,{},{},{}",
-            metadata.generation,
-            metadata.total_dur.unwrap().as_millis(),
+            metrics.generation,
+            metrics.total_dur.unwrap().as_millis(),
             individual.fitness
         );
     }
 
-    fn on_new_generation(&mut self, metadata: &ecrs::ga::Metrics, generation: &[JsspIndividual]) {
+    fn on_new_generation(&mut self, metrics: &ecrs::ga::Metrics, generation: &[JsspIndividual]) {
         // TODO: As this metric is useless right now I'm disabling it temporarily
         // let diversity = self.estimate_pop_diversity(generation);
         let diversity = self.estimate_pop_diversity(generation);
@@ -123,43 +123,43 @@ impl Probe<JsspIndividual> for JsspProbe {
         info!(
             target: "popmetrics",
             "diversity,{},{},{},{diversity},{distance_avg}",
-            metadata.generation,
-            metadata.total_dur.unwrap().as_millis(),
+            metrics.generation,
+            metrics.total_dur.unwrap().as_millis(),
             generation.len()
         );
     }
 
-    fn on_best_fit_in_generation(&mut self, metadata: &ecrs::ga::Metrics, individual: &JsspIndividual) {
+    fn on_best_fit_in_generation(&mut self, metrics: &ecrs::ga::Metrics, individual: &JsspIndividual) {
         info!(
             target: "bestingen",
             "bestingen,{},{},{}",
-            metadata.generation,
-            metadata.total_dur.unwrap().as_millis(),
+            metrics.generation,
+            metrics.total_dur.unwrap().as_millis(),
             individual.fitness
         );
     }
 
     #[inline]
-    fn on_iteration_start(&mut self, _metadata: &ecrs::ga::Metrics) { /* defaults to noop */
+    fn on_iteration_start(&mut self, _metrics: &ecrs::ga::Metrics) { /* defaults to noop */
     }
 
     #[inline]
-    fn on_iteration_end(&mut self, metadata: &ecrs::ga::Metrics) {
+    fn on_iteration_end(&mut self, metrics: &ecrs::ga::Metrics) {
         info!(target: "iterinfo", "iterinfo,{},{},{},{},{},{},{}",
-            metadata.generation,
-            metadata.pop_eval_dur.unwrap().as_millis(),
-            metadata.selection_dur.unwrap().as_millis(),
-            metadata.crossover_dur.unwrap().as_millis(),
-            metadata.mutation_dur.unwrap().as_millis(),
-            metadata.replacement_dur.unwrap().as_millis(),
-            metadata.iteration_dur.unwrap().as_millis()
+            metrics.generation,
+            metrics.pop_eval_dur.unwrap().as_millis(),
+            metrics.selection_dur.unwrap().as_millis(),
+            metrics.crossover_dur.unwrap().as_millis(),
+            metrics.mutation_dur.unwrap().as_millis(),
+            metrics.replacement_dur.unwrap().as_millis(),
+            metrics.iteration_dur.unwrap().as_millis()
         );
     }
 
     #[inline]
     fn on_end(
         &mut self,
-        metadata: &ecrs::ga::Metrics,
+        metrics: &ecrs::ga::Metrics,
         _population: &[JsspIndividual],
         best_individual: &JsspIndividual,
     ) {
@@ -201,8 +201,8 @@ impl Probe<JsspIndividual> for JsspProbe {
             solution_string,
             hash: format!("{:x}", hash),
             fitness: best_individual.fitness,
-            generation_count: metadata.generation,
-            total_time: metadata.total_dur.unwrap().as_millis(),
+            generation_count: metrics.generation,
+            total_time: metrics.total_dur.unwrap().as_millis(),
             chromosome: best_individual.chromosome(),
         };
         let serialized_object = serde_json::to_string_pretty(&outdata).unwrap();

--- a/examples/jssp/problem/probe.rs
+++ b/examples/jssp/problem/probe.rs
@@ -93,11 +93,7 @@ impl Probe<JsspIndividual> for JsspProbe {
         info!(target: "iterinfo", "event_name,generation,eval_time,sel_time,cross_time,mut_time,repl_time,iter_time");
     }
 
-    fn on_initial_population_created(
-        &mut self,
-        metadata: &ecrs::ga::Metrics,
-        population: &[JsspIndividual],
-    ) {
+    fn on_initial_population_created(&mut self, metadata: &ecrs::ga::Metrics, population: &[JsspIndividual]) {
         debug_assert_eq!(self.repeated.len(), 0);
         self.repeated.resize(population.len(), false);
 

--- a/examples/jssp/problem/replacement.rs
+++ b/examples/jssp/problem/replacement.rs
@@ -1,5 +1,5 @@
 use ecrs::{
-    ga::GAMetadata,
+    ga::Metrics,
     prelude::{population::PopulationGenerator, replacement::ReplacementOperator},
 };
 
@@ -24,7 +24,7 @@ impl JsspReplacement {
 impl ReplacementOperator<JsspIndividual> for JsspReplacement {
     fn apply(
         &mut self,
-        _metadata: &GAMetadata,
+        _metadata: &Metrics,
         mut population: Vec<JsspIndividual>,
         mut children: Vec<JsspIndividual>,
     ) -> Vec<JsspIndividual> {
@@ -80,7 +80,7 @@ impl ReplaceWithRandomPopulation {
 impl ReplacementOperator<JsspIndividual> for ReplaceWithRandomPopulation {
     fn apply(
         &mut self,
-        _metadata: &GAMetadata,
+        _metadata: &Metrics,
         population: Vec<JsspIndividual>,
         _children: Vec<JsspIndividual>,
     ) -> Vec<JsspIndividual> {

--- a/examples/jssp/problem/replacement.rs
+++ b/examples/jssp/problem/replacement.rs
@@ -24,7 +24,7 @@ impl JsspReplacement {
 impl ReplacementOperator<JsspIndividual> for JsspReplacement {
     fn apply(
         &mut self,
-        _metadata: &Metrics,
+        _metrics: &Metrics,
         mut population: Vec<JsspIndividual>,
         mut children: Vec<JsspIndividual>,
     ) -> Vec<JsspIndividual> {
@@ -80,7 +80,7 @@ impl ReplaceWithRandomPopulation {
 impl ReplacementOperator<JsspIndividual> for ReplaceWithRandomPopulation {
     fn apply(
         &mut self,
-        _metadata: &Metrics,
+        _metrics: &Metrics,
         population: Vec<JsspIndividual>,
         _children: Vec<JsspIndividual>,
     ) -> Vec<JsspIndividual> {

--- a/examples/jssp/problem/selection.rs
+++ b/examples/jssp/problem/selection.rs
@@ -13,7 +13,7 @@ impl EmptySelection {
 impl SelectionOperator<JsspIndividual> for EmptySelection {
     fn apply<'a>(
         &mut self,
-        _metadata: &ecrs::ga::Metrics,
+        _metrics: &ecrs::ga::Metrics,
         _population: &'a [JsspIndividual],
         _count: usize,
     ) -> Vec<&'a JsspIndividual> {

--- a/examples/jssp/problem/selection.rs
+++ b/examples/jssp/problem/selection.rs
@@ -13,7 +13,7 @@ impl EmptySelection {
 impl SelectionOperator<JsspIndividual> for EmptySelection {
     fn apply<'a>(
         &mut self,
-        _metadata: &ecrs::ga::GAMetadata,
+        _metadata: &ecrs::ga::Metrics,
         _population: &'a [JsspIndividual],
         _count: usize,
     ) -> Vec<&'a JsspIndividual> {

--- a/src/ga.rs
+++ b/src/ga.rs
@@ -173,7 +173,7 @@ where
 }
 
 #[derive(Default)]
-pub struct GAMetadata {
+pub struct Metrics {
     pub generation: usize,
     pub start_time: Option<std::time::Instant>,
 
@@ -190,13 +190,13 @@ pub struct GAMetadata {
     pub iteration_dur: Option<std::time::Duration>,
 }
 
-impl GAMetadata {
+impl Metrics {
     pub fn new(
         start_time: Option<std::time::Instant>,
         duration: Option<std::time::Duration>,
         generation: usize,
     ) -> Self {
-        GAMetadata {
+        Metrics {
             generation,
             start_time,
             total_dur: duration,
@@ -223,7 +223,7 @@ where
     ProbeT: Probe<IndividualT>,
 {
     config: GAConfig<IndividualT, MutOpT, CrossOpT, SelOpT, ReplOpT, PopGenT, FitnessT, ProbeT>,
-    metadata: GAMetadata,
+    metadata: Metrics,
     timer: Timer,
 }
 
@@ -246,7 +246,7 @@ where
                                                           // now
         GeneticSolver {
             config,
-            metadata: GAMetadata::new(None, None, 0),
+            metadata: Metrics::new(None, None, 0),
             timer: Timer::new(),
         }
     }
@@ -382,10 +382,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::GAMetadata;
+    use super::Metrics;
 
     #[test]
     fn gametadata_can_be_constructed_with_new_fn() {
-        GAMetadata::new(None, None, 0);
+        Metrics::new(None, None, 0);
     }
 }

--- a/src/ga.rs
+++ b/src/ga.rs
@@ -339,6 +339,12 @@ where
                 .apply(&self.metadata, population, children);
             self.metadata.replacement_dur = Some(self.timer.elapsed());
 
+            assert_eq!(population.len(), self.config.params.population_size,
+                "There was change in population size from {} to {} in generation {}. Dynamic population size is currently not supported.",
+                self.config.params.population_size,
+                population.len(),
+                generation_no);
+
             // 7. Check for stop condition (Is good enough individual found)? If not goto 2.
             self.timer.start();
             self.eval_pop(&mut population);

--- a/src/ga.rs
+++ b/src/ga.rs
@@ -242,8 +242,6 @@ where
     pub fn new(
         config: GAConfig<IndividualT, MutOpT, CrossOpT, SelOpT, ReplOpT, PopGenT, FitnessT, ProbeT>,
     ) -> Self {
-        assert_eq!(config.params.population_size % 2, 0); // Required for most of operators right
-                                                          // now
         GeneticSolver {
             config,
             metadata: Metrics::new(None, None, 0),

--- a/src/ga/operators/crossover.rs
+++ b/src/ga/operators/crossover.rs
@@ -4,7 +4,7 @@ pub mod impls;
 pub use impls::*;
 
 use crate::ga::individual::IndividualTrait;
-use crate::ga::GAMetadata;
+use crate::ga::Metrics;
 
 /// # Crossover Operator
 ///
@@ -32,5 +32,5 @@ pub trait CrossoverOperator<IndividualT: IndividualTrait> {
     /// ## Returns
     ///
     /// Vector of individuals created during the crossover stage.
-    fn apply(&mut self, metadata: &GAMetadata, selected: &[&IndividualT]) -> Vec<IndividualT>;
+    fn apply(&mut self, metadata: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT>;
 }

--- a/src/ga/operators/crossover.rs
+++ b/src/ga/operators/crossover.rs
@@ -14,7 +14,7 @@ pub trait CrossoverOperator<IndividualT: IndividualTrait> {
     /// FIXME: Understand lifetimes here!
     // fn apply_iter<'i, InputIter, OutputIter>(
     //     &mut self,
-    //     metadata: &GAMetadata,
+    //     metrics: &Metrics,
     //     selected: InputIter,
     // ) -> OutputIter
     // where
@@ -26,11 +26,11 @@ pub trait CrossoverOperator<IndividualT: IndividualTrait> {
     ///
     /// ## Arguments
     ///
-    /// * `metadata` - metadata provided by the GA runtime,
+    /// * `metrics` - metrics provided by the GA runtime,
     /// * `selected` - result of running selection operator,
     ///
     /// ## Returns
     ///
     /// Vector of individuals created during the crossover stage.
-    fn apply(&mut self, metadata: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT>;
+    fn apply(&mut self, metrics: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT>;
 }

--- a/src/ga/operators/crossover/impls.rs
+++ b/src/ga/operators/crossover/impls.rs
@@ -26,7 +26,7 @@ pub use uniform_parameterized::UniformParameterized;
 mod test {
     use crate::ga::individual::IndividualTrait;
     use crate::ga::operators::crossover::{CrossoverOperator, FixedPoint, Pmx, Ppx, Shuffle};
-    use crate::ga::{GAMetadata, Individual};
+    use crate::ga::{Metrics, Individual};
     use std::iter::zip;
 
     #[test]
@@ -66,7 +66,7 @@ mod test {
         let p1 = Individual::from(vec![8, 4, 7, 3, 6, 2, 5, 1, 9, 0]);
         let p2 = Individual::from(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
-        let children = op.apply(&GAMetadata::default(), &[&p1, &p2]);
+        let children = op.apply(&Metrics::default(), &[&p1, &p2]);
         let child_1 = &children[0];
         let child_2 = &children[1];
         assert_eq!(child_1.chromosome.len(), 10);
@@ -80,7 +80,7 @@ mod test {
         let p1 = Individual::from(vec![1, 0, 0, 1, 0, 1, 0, 1, 0, 0]);
         let p2 = Individual::from(vec![0, 1, 1, 0, 1, 0, 1, 0, 1, 1]);
 
-        let children = op.apply(&GAMetadata::default(), &[&p1, &p2]);
+        let children = op.apply(&Metrics::default(), &[&p1, &p2]);
         let child_1 = &children[0];
         let child_2 = &children[1];
         for (g1, g2) in child_1.chromosome.iter().zip(child_2.chromosome.iter()) {
@@ -99,7 +99,7 @@ mod test {
         let p1 = Individual::from(parent_1_chromosome.clone());
         let p2 = Individual::from(parent_2_chromosome.clone());
 
-        let children = op.apply(&GAMetadata::default(), &[&p1, &p2]);
+        let children = op.apply(&Metrics::default(), &[&p1, &p2]);
         let child_1 = &children[0];
         let child_2 = &children[1];
 

--- a/src/ga/operators/crossover/impls.rs
+++ b/src/ga/operators/crossover/impls.rs
@@ -26,7 +26,7 @@ pub use uniform_parameterized::UniformParameterized;
 mod test {
     use crate::ga::individual::IndividualTrait;
     use crate::ga::operators::crossover::{CrossoverOperator, FixedPoint, Pmx, Ppx, Shuffle};
-    use crate::ga::{Metrics, Individual};
+    use crate::ga::{Individual, Metrics};
     use std::iter::zip;
 
     #[test]

--- a/src/ga/operators/crossover/impls/fixed_point.rs
+++ b/src/ga/operators/crossover/impls/fixed_point.rs
@@ -3,7 +3,7 @@ use len_trait::Len;
 use std::ops::IndexMut;
 
 use crate::ga::individual::IndividualTrait;
-use crate::ga::GAMetadata;
+use crate::ga::Metrics;
 
 use super::CrossoverOperator;
 
@@ -36,7 +36,7 @@ impl FixedPoint {
     /// * `parent_2` - Second parent to take part in recombination
     fn apply_single<GeneT, IndividualT>(
         &mut self,
-        _metadata: &GAMetadata,
+        _metadata: &Metrics,
         parent_1: &IndividualT,
         parent_2: &IndividualT,
     ) -> (IndividualT, IndividualT)
@@ -73,7 +73,7 @@ where
     ///
     /// * `metadata` - algorithm state metadata, see the structure details for more info,
     /// * `selected` - references to individuals selected during selection step.
-    fn apply(&mut self, metadata: &GAMetadata, selected: &[&IndividualT]) -> Vec<IndividualT> {
+    fn apply(&mut self, metadata: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
         assert!(selected.len() & 1 == 0);
 
         let mut output = Vec::with_capacity(selected.len());

--- a/src/ga/operators/crossover/impls/fixed_point.rs
+++ b/src/ga/operators/crossover/impls/fixed_point.rs
@@ -36,7 +36,7 @@ impl FixedPoint {
     /// * `parent_2` - Second parent to take part in recombination
     fn apply_single<GeneT, IndividualT>(
         &mut self,
-        _metadata: &Metrics,
+        _metrics: &Metrics,
         parent_1: &IndividualT,
         parent_2: &IndividualT,
     ) -> (IndividualT, IndividualT)
@@ -71,15 +71,15 @@ where
     ///
     /// ## Arguments
     ///
-    /// * `metadata` - algorithm state metadata, see the structure details for more info,
+    /// * `metrics` - algorithm state metrics, see the structure details for more info,
     /// * `selected` - references to individuals selected during selection step.
-    fn apply(&mut self, metadata: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
+    fn apply(&mut self, metrics: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
         assert!(selected.len() & 1 == 0);
 
         let mut output = Vec::with_capacity(selected.len());
 
         for parents in selected.chunks(2) {
-            let (child_1, child_2) = self.apply_single(metadata, parents[0], parents[1]);
+            let (child_1, child_2) = self.apply_single(metrics, parents[0], parents[1]);
             output.push(child_1);
             output.push(child_2);
         }

--- a/src/ga/operators/crossover/impls/multi_point.rs
+++ b/src/ga/operators/crossover/impls/multi_point.rs
@@ -64,7 +64,7 @@ impl<R: Rng> MultiPoint<R> {
     /// * `parent_2` - Second parent to take part in recombination
     fn apply_single<GeneT, IndividualT>(
         &mut self,
-        _metadata: &Metrics,
+        _metrics: &Metrics,
         parent_1: &IndividualT,
         parent_2: &IndividualT,
     ) -> (IndividualT, IndividualT)
@@ -134,15 +134,15 @@ where
     ///
     /// ## Arguments
     ///
-    /// * `metadata` - algorithm state metadata, see the structure details for more info,
+    /// * `metrics` - algorithm state metrics, see the structure details for more info,
     /// * `selected` - references to individuals selected during selection step.
-    fn apply(&mut self, metadata: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
+    fn apply(&mut self, metrics: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
         assert!(selected.len() & 1 == 0);
 
         let mut output = Vec::with_capacity(selected.len());
 
         for parents in selected.chunks(2) {
-            let (child_1, child_2) = self.apply_single(metadata, parents[0], parents[1]);
+            let (child_1, child_2) = self.apply_single(metrics, parents[0], parents[1]);
             output.push(child_1);
             output.push(child_2);
         }

--- a/src/ga/operators/crossover/impls/multi_point.rs
+++ b/src/ga/operators/crossover/impls/multi_point.rs
@@ -3,7 +3,7 @@ use len_trait::Len;
 use std::ops::Index;
 
 use crate::ga::individual::IndividualTrait;
-use crate::ga::GAMetadata;
+use crate::ga::Metrics;
 use push_trait::{Nothing, Push};
 
 use rand::{rngs::ThreadRng, Rng};
@@ -64,7 +64,7 @@ impl<R: Rng> MultiPoint<R> {
     /// * `parent_2` - Second parent to take part in recombination
     fn apply_single<GeneT, IndividualT>(
         &mut self,
-        _metadata: &GAMetadata,
+        _metadata: &Metrics,
         parent_1: &IndividualT,
         parent_2: &IndividualT,
     ) -> (IndividualT, IndividualT)
@@ -136,7 +136,7 @@ where
     ///
     /// * `metadata` - algorithm state metadata, see the structure details for more info,
     /// * `selected` - references to individuals selected during selection step.
-    fn apply(&mut self, metadata: &GAMetadata, selected: &[&IndividualT]) -> Vec<IndividualT> {
+    fn apply(&mut self, metadata: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
         assert!(selected.len() & 1 == 0);
 
         let mut output = Vec::with_capacity(selected.len());

--- a/src/ga/operators/crossover/impls/ordered.rs
+++ b/src/ga/operators/crossover/impls/ordered.rs
@@ -109,7 +109,7 @@ impl<R: Rng> OrderedCrossover<R> {
     /// * `parent_2` - Second parent to take part in crossover
     fn apply_single<GeneT, IndividualT>(
         &mut self,
-        _metadata: &Metrics,
+        _metrics: &Metrics,
         parent_1: &IndividualT,
         parent_2: &IndividualT,
     ) -> (IndividualT, IndividualT)
@@ -161,15 +161,15 @@ where
     ///
     /// ## Arguments
     ///
-    /// * `metadata` - algorithm state metadata, see the structure details for more info,
+    /// * `metrics` - algorithm state metrics, see the structure details for more info,
     /// * `selected` - references to individuals selected during selection step.
-    fn apply(&mut self, metadata: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
+    fn apply(&mut self, metrics: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
         assert!(selected.len() & 1 == 0);
 
         let mut output = Vec::with_capacity(selected.len());
 
         for parents in selected.chunks(2) {
-            let (child_1, child_2) = self.apply_single(metadata, parents[0], parents[1]);
+            let (child_1, child_2) = self.apply_single(metrics, parents[0], parents[1]);
             output.push(child_1);
             output.push(child_2);
         }

--- a/src/ga/operators/crossover/impls/ordered.rs
+++ b/src/ga/operators/crossover/impls/ordered.rs
@@ -4,7 +4,7 @@ use std::hash::Hash;
 use std::ops::Index;
 
 use crate::ga::individual::IndividualTrait;
-use crate::ga::GAMetadata;
+use crate::ga::Metrics;
 use push_trait::{Nothing, Push};
 
 use rand::{rngs::ThreadRng, Rng};
@@ -109,7 +109,7 @@ impl<R: Rng> OrderedCrossover<R> {
     /// * `parent_2` - Second parent to take part in crossover
     fn apply_single<GeneT, IndividualT>(
         &mut self,
-        _metadata: &GAMetadata,
+        _metadata: &Metrics,
         parent_1: &IndividualT,
         parent_2: &IndividualT,
     ) -> (IndividualT, IndividualT)
@@ -163,7 +163,7 @@ where
     ///
     /// * `metadata` - algorithm state metadata, see the structure details for more info,
     /// * `selected` - references to individuals selected during selection step.
-    fn apply(&mut self, metadata: &GAMetadata, selected: &[&IndividualT]) -> Vec<IndividualT> {
+    fn apply(&mut self, metadata: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
         assert!(selected.len() & 1 == 0);
 
         let mut output = Vec::with_capacity(selected.len());

--- a/src/ga/operators/crossover/impls/pmx.rs
+++ b/src/ga/operators/crossover/impls/pmx.rs
@@ -5,7 +5,7 @@ use std::hash::Hash;
 use std::ops::Index;
 
 use crate::ga::individual::{Chromosome, IndividualTrait};
-use crate::ga::GAMetadata;
+use crate::ga::Metrics;
 use push_trait::{Nothing, Push};
 
 use rand::{rngs::ThreadRng, Rng};
@@ -148,7 +148,7 @@ impl<R: Rng> Pmx<R> {
     /// * `parent_2` - Second parent to take part in crossover
     fn apply_single<GeneT, IndividualT>(
         &mut self,
-        _metadata: &GAMetadata,
+        _metadata: &Metrics,
         parent_1: &IndividualT,
         parent_2: &IndividualT,
     ) -> (IndividualT, IndividualT)
@@ -207,7 +207,7 @@ where
     ///
     /// * `metadata` - algorithm state metadata, see the structure details for more info,
     /// * `selected` - references to individuals selected during selection step.
-    fn apply(&mut self, metadata: &GAMetadata, selected: &[&IndividualT]) -> Vec<IndividualT> {
+    fn apply(&mut self, metadata: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
         assert!(selected.len() & 1 == 0);
 
         let mut output = Vec::with_capacity(selected.len());

--- a/src/ga/operators/crossover/impls/pmx.rs
+++ b/src/ga/operators/crossover/impls/pmx.rs
@@ -148,7 +148,7 @@ impl<R: Rng> Pmx<R> {
     /// * `parent_2` - Second parent to take part in crossover
     fn apply_single<GeneT, IndividualT>(
         &mut self,
-        _metadata: &Metrics,
+        _metrics: &Metrics,
         parent_1: &IndividualT,
         parent_2: &IndividualT,
     ) -> (IndividualT, IndividualT)
@@ -205,15 +205,15 @@ where
     ///
     /// ## Arguments
     ///
-    /// * `metadata` - algorithm state metadata, see the structure details for more info,
+    /// * `metrics` - algorithm state metrics, see the structure details for more info,
     /// * `selected` - references to individuals selected during selection step.
-    fn apply(&mut self, metadata: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
+    fn apply(&mut self, metrics: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
         assert!(selected.len() & 1 == 0);
 
         let mut output = Vec::with_capacity(selected.len());
 
         for parents in selected.chunks(2) {
-            let (child_1, child_2) = self.apply_single(metadata, parents[0], parents[1]);
+            let (child_1, child_2) = self.apply_single(metrics, parents[0], parents[1]);
             output.push(child_1);
             output.push(child_2);
         }

--- a/src/ga/operators/crossover/impls/ppx.rs
+++ b/src/ga/operators/crossover/impls/ppx.rs
@@ -5,7 +5,7 @@ use std::hash::Hash;
 use std::ops::Index;
 
 use crate::ga::individual::IndividualTrait;
-use crate::ga::GAMetadata;
+use crate::ga::Metrics;
 use push_trait::{Nothing, Push};
 
 use rand::{rngs::ThreadRng, Rng};
@@ -109,7 +109,7 @@ impl<R: Rng> Ppx<R> {
     /// * `parent_2` - one of the parents to take part in crossover
     fn apply_single<GeneT, IndividualT>(
         &mut self,
-        _metadata: &GAMetadata,
+        _metadata: &Metrics,
         parent_1: &IndividualT,
         parent_2: &IndividualT,
     ) -> (IndividualT, IndividualT)
@@ -166,7 +166,7 @@ where
     ///
     /// * `metadata` - algorithm state metadata, see the structure details for more info,
     /// * `selected` - references to individuals selected during selection step.
-    fn apply(&mut self, metadata: &GAMetadata, selected: &[&IndividualT]) -> Vec<IndividualT> {
+    fn apply(&mut self, metadata: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
         assert!(selected.len() & 1 == 0);
 
         let mut output = Vec::with_capacity(selected.len());

--- a/src/ga/operators/crossover/impls/ppx.rs
+++ b/src/ga/operators/crossover/impls/ppx.rs
@@ -109,7 +109,7 @@ impl<R: Rng> Ppx<R> {
     /// * `parent_2` - one of the parents to take part in crossover
     fn apply_single<GeneT, IndividualT>(
         &mut self,
-        _metadata: &Metrics,
+        _metrics: &Metrics,
         parent_1: &IndividualT,
         parent_2: &IndividualT,
     ) -> (IndividualT, IndividualT)
@@ -164,15 +164,15 @@ where
     ///
     /// ## Arguments
     ///
-    /// * `metadata` - algorithm state metadata, see the structure details for more info,
+    /// * `metrics` - algorithm state metrics, see the structure details for more info,
     /// * `selected` - references to individuals selected during selection step.
-    fn apply(&mut self, metadata: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
+    fn apply(&mut self, metrics: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
         assert!(selected.len() & 1 == 0);
 
         let mut output = Vec::with_capacity(selected.len());
 
         for parents in selected.chunks(2) {
-            let (child_1, child_2) = self.apply_single(metadata, parents[0], parents[1]);
+            let (child_1, child_2) = self.apply_single(metrics, parents[0], parents[1]);
             output.push(child_1);
             output.push(child_2);
         }

--- a/src/ga/operators/crossover/impls/shuffle.rs
+++ b/src/ga/operators/crossover/impls/shuffle.rs
@@ -2,7 +2,7 @@ use itertools::{enumerate, Itertools};
 use len_trait::Len;
 
 use crate::ga::individual::IndividualTrait;
-use crate::ga::GAMetadata;
+use crate::ga::Metrics;
 use push_trait::{Nothing, Push};
 use rand::prelude::SliceRandom;
 use rand::{rngs::ThreadRng, Rng};
@@ -56,7 +56,7 @@ impl<R: Rng> Shuffle<R> {
     /// * `parent_2` - Second parent to take part in recombination
     fn apply_single<GeneT, IndividualT>(
         &mut self,
-        _metadata: &GAMetadata,
+        _metadata: &Metrics,
         parent_1: &IndividualT,
         parent_2: &IndividualT,
     ) -> (IndividualT, IndividualT)
@@ -111,7 +111,7 @@ where
     ///
     /// * `metadata` - algorithm state metadata, see the structure details for more info,
     /// * `selected` - references to individuals selected during selection step.
-    fn apply(&mut self, metadata: &GAMetadata, selected: &[&IndividualT]) -> Vec<IndividualT> {
+    fn apply(&mut self, metadata: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
         assert!(selected.len() & 1 == 0);
 
         let mut output = Vec::with_capacity(selected.len());

--- a/src/ga/operators/crossover/impls/shuffle.rs
+++ b/src/ga/operators/crossover/impls/shuffle.rs
@@ -56,7 +56,7 @@ impl<R: Rng> Shuffle<R> {
     /// * `parent_2` - Second parent to take part in recombination
     fn apply_single<GeneT, IndividualT>(
         &mut self,
-        _metadata: &Metrics,
+        _metrics: &Metrics,
         parent_1: &IndividualT,
         parent_2: &IndividualT,
     ) -> (IndividualT, IndividualT)
@@ -109,15 +109,15 @@ where
     ///
     /// ## Arguments
     ///
-    /// * `metadata` - algorithm state metadata, see the structure details for more info,
+    /// * `metrics` - algorithm state metrics, see the structure details for more info,
     /// * `selected` - references to individuals selected during selection step.
-    fn apply(&mut self, metadata: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
+    fn apply(&mut self, metrics: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
         assert!(selected.len() & 1 == 0);
 
         let mut output = Vec::with_capacity(selected.len());
 
         for parents in selected.chunks(2) {
-            let (child_1, child_2) = self.apply_single(metadata, parents[0], parents[1]);
+            let (child_1, child_2) = self.apply_single(metrics, parents[0], parents[1]);
             output.push(child_1);
             output.push(child_2);
         }

--- a/src/ga/operators/crossover/impls/single_point.rs
+++ b/src/ga/operators/crossover/impls/single_point.rs
@@ -51,7 +51,7 @@ impl<R: Rng> SinglePoint<R> {
     /// * `parent_2` - Second parent to take part in recombination
     fn apply_single<GeneT, IndividualT>(
         &mut self,
-        _metadata: &Metrics,
+        _metrics: &Metrics,
         parent_1: &IndividualT,
         parent_2: &IndividualT,
     ) -> (IndividualT, IndividualT)
@@ -98,15 +98,15 @@ where
     ///
     /// ## Arguments
     ///
-    /// * `metadata` - algorithm state metadata, see the structure details for more info,
+    /// * `metrics` - algorithm state metrics, see the structure details for more info,
     /// * `selected` - references to individuals selected during selection step.
-    fn apply(&mut self, metadata: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
+    fn apply(&mut self, metrics: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
         assert!(selected.len() & 1 == 0);
 
         let mut output = Vec::with_capacity(selected.len());
 
         for parents in selected.chunks(2) {
-            let (child_1, child_2) = self.apply_single(metadata, parents[0], parents[1]);
+            let (child_1, child_2) = self.apply_single(metrics, parents[0], parents[1]);
             output.push(child_1);
             output.push(child_2);
         }

--- a/src/ga/operators/crossover/impls/single_point.rs
+++ b/src/ga/operators/crossover/impls/single_point.rs
@@ -2,7 +2,7 @@ use len_trait::Len;
 use std::ops::Index;
 
 use crate::ga::individual::IndividualTrait;
-use crate::ga::GAMetadata;
+use crate::ga::Metrics;
 use push_trait::{Nothing, Push};
 
 use rand::{rngs::ThreadRng, Rng};
@@ -51,7 +51,7 @@ impl<R: Rng> SinglePoint<R> {
     /// * `parent_2` - Second parent to take part in recombination
     fn apply_single<GeneT, IndividualT>(
         &mut self,
-        _metadata: &GAMetadata,
+        _metadata: &Metrics,
         parent_1: &IndividualT,
         parent_2: &IndividualT,
     ) -> (IndividualT, IndividualT)
@@ -100,7 +100,7 @@ where
     ///
     /// * `metadata` - algorithm state metadata, see the structure details for more info,
     /// * `selected` - references to individuals selected during selection step.
-    fn apply(&mut self, metadata: &GAMetadata, selected: &[&IndividualT]) -> Vec<IndividualT> {
+    fn apply(&mut self, metadata: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
         assert!(selected.len() & 1 == 0);
 
         let mut output = Vec::with_capacity(selected.len());

--- a/src/ga/operators/crossover/impls/two_point.rs
+++ b/src/ga/operators/crossover/impls/two_point.rs
@@ -52,7 +52,7 @@ impl<R: Rng> TwoPoint<R> {
     /// * `parent_2` - Second parent to take part in recombination
     fn apply_single<GeneT, IndividualT>(
         &mut self,
-        _metadata: &Metrics,
+        _metrics: &Metrics,
         parent_1: &IndividualT,
         parent_2: &IndividualT,
     ) -> (IndividualT, IndividualT)
@@ -120,15 +120,15 @@ where
     ///
     /// ## Arguments
     ///
-    /// * `metadata` - algorithm state metadata, see the structure details for more info,
+    /// * `metrics` - algorithm state metrics, see the structure details for more info,
     /// * `selected` - references to individuals selected during selection step.
-    fn apply(&mut self, metadata: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
+    fn apply(&mut self, metrics: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
         assert!(selected.len() & 1 == 0);
 
         let mut output = Vec::with_capacity(selected.len());
 
         for parents in selected.chunks(2) {
-            let (child_1, child_2) = self.apply_single(metadata, parents[0], parents[1]);
+            let (child_1, child_2) = self.apply_single(metrics, parents[0], parents[1]);
             output.push(child_1);
             output.push(child_2);
         }

--- a/src/ga/operators/crossover/impls/two_point.rs
+++ b/src/ga/operators/crossover/impls/two_point.rs
@@ -3,7 +3,7 @@ use len_trait::Len;
 use std::ops::Index;
 
 use crate::ga::individual::IndividualTrait;
-use crate::ga::GAMetadata;
+use crate::ga::Metrics;
 use push_trait::{Nothing, Push};
 
 use rand::{rngs::ThreadRng, Rng};
@@ -52,7 +52,7 @@ impl<R: Rng> TwoPoint<R> {
     /// * `parent_2` - Second parent to take part in recombination
     fn apply_single<GeneT, IndividualT>(
         &mut self,
-        _metadata: &GAMetadata,
+        _metadata: &Metrics,
         parent_1: &IndividualT,
         parent_2: &IndividualT,
     ) -> (IndividualT, IndividualT)
@@ -122,7 +122,7 @@ where
     ///
     /// * `metadata` - algorithm state metadata, see the structure details for more info,
     /// * `selected` - references to individuals selected during selection step.
-    fn apply(&mut self, metadata: &GAMetadata, selected: &[&IndividualT]) -> Vec<IndividualT> {
+    fn apply(&mut self, metadata: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
         assert!(selected.len() & 1 == 0);
 
         let mut output = Vec::with_capacity(selected.len());

--- a/src/ga/operators/crossover/impls/uniform.rs
+++ b/src/ga/operators/crossover/impls/uniform.rs
@@ -3,7 +3,7 @@ use len_trait::Len;
 use std::ops::Index;
 
 use crate::ga::individual::IndividualTrait;
-use crate::ga::GAMetadata;
+use crate::ga::Metrics;
 use push_trait::{Nothing, Push};
 
 use rand::{rngs::ThreadRng, Rng};
@@ -49,7 +49,7 @@ where
     /// * `parent_2` - Second parent to take part in recombination
     fn apply_single<GeneT, IndividualT>(
         &mut self,
-        _metadata: &GAMetadata,
+        _metadata: &Metrics,
         parent_1: &IndividualT,
         parent_2: &IndividualT,
     ) -> (IndividualT, IndividualT)
@@ -106,7 +106,7 @@ where
     ///
     /// * `metadata` - algorithm state metadata, see the structure details for more info,
     /// * `selected` - references to individuals selected during selection step.
-    fn apply(&mut self, metadata: &GAMetadata, selected: &[&IndividualT]) -> Vec<IndividualT> {
+    fn apply(&mut self, metadata: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
         assert!(selected.len() & 1 == 0);
 
         let mut output = Vec::with_capacity(selected.len());

--- a/src/ga/operators/crossover/impls/uniform.rs
+++ b/src/ga/operators/crossover/impls/uniform.rs
@@ -49,7 +49,7 @@ where
     /// * `parent_2` - Second parent to take part in recombination
     fn apply_single<GeneT, IndividualT>(
         &mut self,
-        _metadata: &Metrics,
+        _metrics: &Metrics,
         parent_1: &IndividualT,
         parent_2: &IndividualT,
     ) -> (IndividualT, IndividualT)
@@ -104,15 +104,15 @@ where
     ///
     /// ## Arguments
     ///
-    /// * `metadata` - algorithm state metadata, see the structure details for more info,
+    /// * `metrics` - algorithm state metrics, see the structure details for more info,
     /// * `selected` - references to individuals selected during selection step.
-    fn apply(&mut self, metadata: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
+    fn apply(&mut self, metrics: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
         assert!(selected.len() & 1 == 0);
 
         let mut output = Vec::with_capacity(selected.len());
 
         for parents in selected.chunks(2) {
-            let (child_1, child_2) = self.apply_single(metadata, parents[0], parents[1]);
+            let (child_1, child_2) = self.apply_single(metrics, parents[0], parents[1]);
             output.push(child_1);
             output.push(child_2);
         }

--- a/src/ga/operators/crossover/impls/uniform_parameterized.rs
+++ b/src/ga/operators/crossover/impls/uniform_parameterized.rs
@@ -3,7 +3,7 @@ use len_trait::Len;
 use std::ops::Index;
 
 use crate::ga::individual::IndividualTrait;
-use crate::ga::GAMetadata;
+use crate::ga::Metrics;
 use push_trait::{Nothing, Push};
 
 use rand::{rngs::ThreadRng, Rng};
@@ -55,7 +55,7 @@ where
     /// * `parent_2` - Second parent to take part in recombination
     fn apply_single<GeneT, IndividualT>(
         &mut self,
-        _metadata: &GAMetadata,
+        _metadata: &Metrics,
         parent_1: &IndividualT,
         parent_2: &IndividualT,
     ) -> (IndividualT, IndividualT)
@@ -108,7 +108,7 @@ where
     ///
     /// * `metadata` - algorithm state metadata, see the structure details for more info,
     /// * `selected` - references to individuals selected during selection step.
-    fn apply(&mut self, metadata: &GAMetadata, selected: &[&IndividualT]) -> Vec<IndividualT> {
+    fn apply(&mut self, metadata: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
         assert!(selected.len() & 1 == 0);
 
         let mut output = Vec::with_capacity(selected.len());

--- a/src/ga/operators/crossover/impls/uniform_parameterized.rs
+++ b/src/ga/operators/crossover/impls/uniform_parameterized.rs
@@ -55,7 +55,7 @@ where
     /// * `parent_2` - Second parent to take part in recombination
     fn apply_single<GeneT, IndividualT>(
         &mut self,
-        _metadata: &Metrics,
+        _metrics: &Metrics,
         parent_1: &IndividualT,
         parent_2: &IndividualT,
     ) -> (IndividualT, IndividualT)
@@ -106,15 +106,15 @@ where
     ///
     /// ## Arguments
     ///
-    /// * `metadata` - algorithm state metadata, see the structure details for more info,
+    /// * `metrics` - algorithm state metrics, see the structure details for more info,
     /// * `selected` - references to individuals selected during selection step.
-    fn apply(&mut self, metadata: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
+    fn apply(&mut self, metrics: &Metrics, selected: &[&IndividualT]) -> Vec<IndividualT> {
         assert!(selected.len() & 1 == 0);
 
         let mut output = Vec::with_capacity(selected.len());
 
         for parents in selected.chunks(2) {
-            let (child_1, child_2) = self.apply_single(metadata, parents[0], parents[1]);
+            let (child_1, child_2) = self.apply_single(metrics, parents[0], parents[1]);
             output.push(child_1);
             output.push(child_2);
         }

--- a/src/ga/operators/mutation.rs
+++ b/src/ga/operators/mutation.rs
@@ -15,6 +15,5 @@ pub trait MutationOperator<IndividualT: IndividualTrait> {
     /// ## Arguments
     ///
     /// * `individual` - mutable reference to to-be-mutated individual
-    /// * `mutation_rate` - probability of gene mutation
     fn apply(&mut self, metadata: &GAMetadata, individual: &mut IndividualT);
 }

--- a/src/ga/operators/mutation.rs
+++ b/src/ga/operators/mutation.rs
@@ -3,7 +3,7 @@ pub mod impls;
 #[cfg(feature = "ga_impl_mutation")]
 pub use impls::*;
 
-use crate::ga::{individual::IndividualTrait, GAMetadata};
+use crate::ga::{individual::IndividualTrait, Metrics};
 
 /// # Mutation Operator
 ///
@@ -15,5 +15,5 @@ pub trait MutationOperator<IndividualT: IndividualTrait> {
     /// ## Arguments
     ///
     /// * `individual` - mutable reference to to-be-mutated individual
-    fn apply(&mut self, metadata: &GAMetadata, individual: &mut IndividualT);
+    fn apply(&mut self, metadata: &Metrics, individual: &mut IndividualT);
 }

--- a/src/ga/operators/mutation.rs
+++ b/src/ga/operators/mutation.rs
@@ -15,5 +15,5 @@ pub trait MutationOperator<IndividualT: IndividualTrait> {
     /// ## Arguments
     ///
     /// * `individual` - mutable reference to to-be-mutated individual
-    fn apply(&mut self, metadata: &Metrics, individual: &mut IndividualT);
+    fn apply(&mut self, metrics: &Metrics, individual: &mut IndividualT);
 }

--- a/src/ga/operators/mutation/impls.rs
+++ b/src/ga/operators/mutation/impls.rs
@@ -39,6 +39,8 @@ pub struct FlipBit<R: Rng = ThreadRng> {
 
 impl FlipBit<ThreadRng> {
     /// Returns new instance of [FlipBit] mutation operator with default RNG
+    ///
+    /// * `mutation_rate` - probability of gene mutation
     pub fn new(mutation_rate: f64) -> Self {
         Self::with_rng(mutation_rate, rand::thread_rng())
     }
@@ -90,6 +92,8 @@ pub struct Interchange<R: Rng = ThreadRng> {
 
 impl Interchange<ThreadRng> {
     /// Returns new instance of [Interchange] mutation operator with default RNG
+    ///
+    /// * `mutation_rate` - probability of gene mutation
     pub fn new(mutation_rate: f64) -> Self {
         Self::with_rng(mutation_rate, rand::thread_rng())
     }
@@ -116,7 +120,6 @@ where
     /// ## Arguments
     ///
     /// * `individual` - mutable reference to to-be-mutated individual
-    /// * `mutation_rate` - probability of gene mutation
     fn apply(&mut self, _metadata: &GAMetadata, individual: &mut IndividualT) {
         let chromosome_ref = individual.chromosome_mut();
         let chromosome_len = chromosome_ref.len();
@@ -147,6 +150,8 @@ pub struct Reversing<R: Rng = ThreadRng> {
 
 impl Reversing<ThreadRng> {
     /// Returns new instance of [Reversing] mutation operator with default RNG
+    ///
+    /// * `mutation_rate` - probability of gene mutation
     pub fn new(mutation_rate: f64) -> Self {
         Self::with_rng(mutation_rate, rand::thread_rng())
     }
@@ -173,7 +178,6 @@ where
     /// ## Arguments
     ///
     /// * `individual` - mutable reference to to-be-mutated individual
-    /// * `mutation_rate` - probability of gene mutation
     fn apply(&mut self, _metadata: &GAMetadata, individual: &mut IndividualT) {
         let dist = rand::distributions::Uniform::from(0.0..1.0);
         let chromosome_ref = individual.chromosome_mut();
@@ -203,6 +207,8 @@ pub struct Inversion<GeneT: Copy, R: Rng = ThreadRng> {
 
 impl<GeneT: Copy> Inversion<GeneT, ThreadRng> {
     /// Returns new instance of [Inversion] mutation operator with default RNG
+    ///
+    /// * `mutation_rate` - probability of gene mutation
     pub fn new(mutation_rate: f64) -> Self {
         Self::with_rng(mutation_rate, rand::thread_rng())
     }
@@ -231,7 +237,6 @@ where
     /// ## Arguments
     ///
     /// * `individual` - mutable reference to to-be-mutated individual
-    /// * `mutation_rate` - probability of gene mutation
     fn apply(&mut self, _metadata: &GAMetadata, individual: &mut IndividualT) {
         let _marker: PhantomData<GeneT> = PhantomData;
 

--- a/src/ga/operators/mutation/impls.rs
+++ b/src/ga/operators/mutation/impls.rs
@@ -4,7 +4,7 @@ use len_trait::Len;
 use push_trait::{Nothing, Push};
 use rand::{rngs::ThreadRng, Rng};
 
-use crate::ga::{individual::IndividualTrait, GAMetadata};
+use crate::ga::{individual::IndividualTrait, Metrics};
 
 use super::MutationOperator;
 
@@ -24,7 +24,7 @@ impl Identity {
 }
 
 impl<IndividualT: IndividualTrait> MutationOperator<IndividualT> for Identity {
-    fn apply(&mut self, _metadata: &GAMetadata, _individual: &mut IndividualT) {}
+    fn apply(&mut self, _metadata: &Metrics, _individual: &mut IndividualT) {}
 }
 
 /// ### Flilp bit mutation operator
@@ -67,7 +67,7 @@ where
     ///
     /// * `individual` - mutable reference to to-be-mutated individual
     /// * `mutation_rate` - probability of gene mutation
-    fn apply(&mut self, _metadata: &GAMetadata, individual: &mut IndividualT) {
+    fn apply(&mut self, _metadata: &Metrics, individual: &mut IndividualT) {
         let distribution = rand::distributions::Uniform::from(0.0..1.0);
         let chromosome_ref = individual.chromosome_mut();
         let chromosome_len = chromosome_ref.len();
@@ -120,7 +120,7 @@ where
     /// ## Arguments
     ///
     /// * `individual` - mutable reference to to-be-mutated individual
-    fn apply(&mut self, _metadata: &GAMetadata, individual: &mut IndividualT) {
+    fn apply(&mut self, _metadata: &Metrics, individual: &mut IndividualT) {
         let chromosome_ref = individual.chromosome_mut();
         let chromosome_len = chromosome_ref.len();
 
@@ -178,7 +178,7 @@ where
     /// ## Arguments
     ///
     /// * `individual` - mutable reference to to-be-mutated individual
-    fn apply(&mut self, _metadata: &GAMetadata, individual: &mut IndividualT) {
+    fn apply(&mut self, _metadata: &Metrics, individual: &mut IndividualT) {
         let dist = rand::distributions::Uniform::from(0.0..1.0);
         let chromosome_ref = individual.chromosome_mut();
         let chromosome_len = chromosome_ref.len();
@@ -237,7 +237,7 @@ where
     /// ## Arguments
     ///
     /// * `individual` - mutable reference to to-be-mutated individual
-    fn apply(&mut self, _metadata: &GAMetadata, individual: &mut IndividualT) {
+    fn apply(&mut self, _metadata: &Metrics, individual: &mut IndividualT) {
         let _marker: PhantomData<GeneT> = PhantomData;
 
         let r: f64 = self.rng.gen();
@@ -260,7 +260,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::ga::{individual::IndividualTrait, GAMetadata, Individual};
+    use crate::ga::{individual::IndividualTrait, Metrics, Individual};
     use itertools::Itertools;
     use rand::{distributions::Uniform, Rng};
 
@@ -280,7 +280,7 @@ mod tests {
 
         let mut identity_mutation = Identity;
 
-        identity_mutation.apply(&GAMetadata::default(), &mut individual);
+        identity_mutation.apply(&Metrics::default(), &mut individual);
 
         assert_eq!(chromosome, individual.chromosome);
     }
@@ -302,7 +302,7 @@ mod tests {
 
         let mut operator = FlipBit::new(1.);
 
-        operator.apply(&GAMetadata::default(), &mut individual);
+        operator.apply(&Metrics::default(), &mut individual);
 
         for (actual, expected) in std::iter::zip(chromosome_clone, individual.chromosome()) {
             assert_eq!(actual, !*expected);
@@ -326,7 +326,7 @@ mod tests {
 
         let mut operator = FlipBit::new(0.);
 
-        operator.apply(&GAMetadata::default(), &mut individual);
+        operator.apply(&Metrics::default(), &mut individual);
 
         for (actual, expected) in std::iter::zip(chromosome_clone, individual.chromosome()) {
             assert_eq!(actual, *expected);
@@ -350,7 +350,7 @@ mod tests {
 
         let mut operator = Interchange::new(1.);
 
-        operator.apply(&GAMetadata::default(), &mut individual);
+        operator.apply(&Metrics::default(), &mut individual);
         let changes = std::iter::zip(chromosome_clone, individual.chromosome())
             .filter(|p| p.0 != *p.1)
             .count();
@@ -374,7 +374,7 @@ mod tests {
 
         let mut operator = Interchange::new(0.);
 
-        operator.apply(&GAMetadata::default(), &mut individual);
+        operator.apply(&Metrics::default(), &mut individual);
 
         for (actual, expected) in std::iter::zip(chromosome_clone, individual.chromosome()) {
             assert_eq!(actual, *expected);
@@ -397,7 +397,7 @@ mod tests {
 
         let mut operator = Reversing::new(1.0);
 
-        operator.apply(&GAMetadata::default(), &mut individual);
+        operator.apply(&Metrics::default(), &mut individual);
 
         assert_eq!(
             first_gene_value,

--- a/src/ga/operators/mutation/impls.rs
+++ b/src/ga/operators/mutation/impls.rs
@@ -24,7 +24,7 @@ impl Identity {
 }
 
 impl<IndividualT: IndividualTrait> MutationOperator<IndividualT> for Identity {
-    fn apply(&mut self, _metadata: &Metrics, _individual: &mut IndividualT) {}
+    fn apply(&mut self, _metrics: &Metrics, _individual: &mut IndividualT) {}
 }
 
 /// ### Flilp bit mutation operator
@@ -67,7 +67,7 @@ where
     ///
     /// * `individual` - mutable reference to to-be-mutated individual
     /// * `mutation_rate` - probability of gene mutation
-    fn apply(&mut self, _metadata: &Metrics, individual: &mut IndividualT) {
+    fn apply(&mut self, _metrics: &Metrics, individual: &mut IndividualT) {
         let distribution = rand::distributions::Uniform::from(0.0..1.0);
         let chromosome_ref = individual.chromosome_mut();
         let chromosome_len = chromosome_ref.len();
@@ -120,7 +120,7 @@ where
     /// ## Arguments
     ///
     /// * `individual` - mutable reference to to-be-mutated individual
-    fn apply(&mut self, _metadata: &Metrics, individual: &mut IndividualT) {
+    fn apply(&mut self, _metrics: &Metrics, individual: &mut IndividualT) {
         let chromosome_ref = individual.chromosome_mut();
         let chromosome_len = chromosome_ref.len();
 
@@ -178,7 +178,7 @@ where
     /// ## Arguments
     ///
     /// * `individual` - mutable reference to to-be-mutated individual
-    fn apply(&mut self, _metadata: &Metrics, individual: &mut IndividualT) {
+    fn apply(&mut self, _metrics: &Metrics, individual: &mut IndividualT) {
         let dist = rand::distributions::Uniform::from(0.0..1.0);
         let chromosome_ref = individual.chromosome_mut();
         let chromosome_len = chromosome_ref.len();
@@ -237,7 +237,7 @@ where
     /// ## Arguments
     ///
     /// * `individual` - mutable reference to to-be-mutated individual
-    fn apply(&mut self, _metadata: &Metrics, individual: &mut IndividualT) {
+    fn apply(&mut self, _metrics: &Metrics, individual: &mut IndividualT) {
         let _marker: PhantomData<GeneT> = PhantomData;
 
         let r: f64 = self.rng.gen();

--- a/src/ga/operators/mutation/impls.rs
+++ b/src/ga/operators/mutation/impls.rs
@@ -260,7 +260,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::ga::{individual::IndividualTrait, Metrics, Individual};
+    use crate::ga::{individual::IndividualTrait, Individual, Metrics};
     use itertools::Itertools;
     use rand::{distributions::Uniform, Rng};
 

--- a/src/ga/operators/replacement.rs
+++ b/src/ga/operators/replacement.rs
@@ -9,7 +9,7 @@ pub mod impls;
 #[cfg(feature = "ga_impl_replacement")]
 pub use impls::*;
 
-use crate::ga::{individual::IndividualTrait, GAMetadata};
+use crate::ga::{individual::IndividualTrait, Metrics};
 
 /// # Replacement Operator
 ///
@@ -36,7 +36,7 @@ pub trait ReplacementOperator<IndividualT: IndividualTrait> {
     /// * `children` - Result of the crossover phase.
     fn apply(
         &mut self,
-        metadata: &GAMetadata,
+        metadata: &Metrics,
         population: Vec<IndividualT>,
         children: Vec<IndividualT>,
     ) -> Vec<IndividualT>;

--- a/src/ga/operators/replacement.rs
+++ b/src/ga/operators/replacement.rs
@@ -36,7 +36,7 @@ pub trait ReplacementOperator<IndividualT: IndividualTrait> {
     /// * `children` - Result of the crossover phase.
     fn apply(
         &mut self,
-        metadata: &Metrics,
+        metrics: &Metrics,
         population: Vec<IndividualT>,
         children: Vec<IndividualT>,
     ) -> Vec<IndividualT>;

--- a/src/ga/operators/replacement/impls.rs
+++ b/src/ga/operators/replacement/impls.rs
@@ -1,4 +1,4 @@
-use crate::ga::{individual::IndividualTrait, GAMetadata};
+use crate::ga::{individual::IndividualTrait, Metrics};
 
 use super::ReplacementOperator;
 
@@ -38,7 +38,7 @@ impl<IndividualT: IndividualTrait> ReplacementOperator<IndividualT> for BothPare
     #[inline(always)]
     fn apply(
         &mut self,
-        _metadata: &GAMetadata,
+        _metadata: &Metrics,
         _population: Vec<IndividualT>,
         children: Vec<IndividualT>,
     ) -> Vec<IndividualT> {
@@ -73,7 +73,7 @@ impl<IndividualT: IndividualTrait> ReplacementOperator<IndividualT> for Noop {
     #[inline(always)]
     fn apply(
         &mut self,
-        _metadata: &GAMetadata,
+        _metadata: &Metrics,
         population: Vec<IndividualT>,
         _children: Vec<IndividualT>,
     ) -> Vec<IndividualT> {
@@ -141,7 +141,7 @@ impl<IndividualT: IndividualTrait> ReplacementOperator<IndividualT> for WeakPare
     /// * `children` - Result of the crossover phase
     fn apply(
         &mut self,
-        _metadata: &GAMetadata,
+        _metadata: &Metrics,
         mut population: Vec<IndividualT>,
         mut children: Vec<IndividualT>,
     ) -> Vec<IndividualT> {
@@ -182,7 +182,7 @@ impl<IndividualT: IndividualTrait> ReplacementOperator<IndividualT> for WeakPare
 
 #[cfg(test)]
 mod tests {
-    use crate::ga::{GAMetadata, Individual};
+    use crate::ga::{Metrics, Individual};
 
     use super::{BothParents, Noop, ReplacementOperator, WeakParent};
 
@@ -222,7 +222,7 @@ mod tests {
 
         let children_clone = children.clone();
 
-        let result = WeakParent::new().apply(&GAMetadata::default(), parents, children);
+        let result = WeakParent::new().apply(&Metrics::default(), parents, children);
 
         assert_eq!(result, children_clone);
     }
@@ -253,7 +253,7 @@ mod tests {
 
         let parents_clone = parents.clone();
 
-        let result = WeakParent::new().apply(&GAMetadata::default(), parents, children);
+        let result = WeakParent::new().apply(&Metrics::default(), parents, children);
 
         assert_eq!(result, parents_clone);
     }
@@ -293,7 +293,7 @@ mod tests {
             },
         ];
 
-        let result = WeakParent::new().apply(&GAMetadata::default(), parents, children);
+        let result = WeakParent::new().apply(&Metrics::default(), parents, children);
 
         assert_eq!(result, expected_result);
     }
@@ -333,7 +333,7 @@ mod tests {
             },
         ];
 
-        let result = WeakParent::new().apply(&GAMetadata::default(), parents, children);
+        let result = WeakParent::new().apply(&Metrics::default(), parents, children);
 
         assert_eq!(result, expected_result);
     }
@@ -373,7 +373,7 @@ mod tests {
             },
         ];
 
-        let result = WeakParent::new().apply(&GAMetadata::default(), parents, children);
+        let result = WeakParent::new().apply(&Metrics::default(), parents, children);
 
         assert_eq!(result, expected_result);
     }

--- a/src/ga/operators/replacement/impls.rs
+++ b/src/ga/operators/replacement/impls.rs
@@ -38,7 +38,7 @@ impl<IndividualT: IndividualTrait> ReplacementOperator<IndividualT> for BothPare
     #[inline(always)]
     fn apply(
         &mut self,
-        _metadata: &Metrics,
+        _metrics: &Metrics,
         _population: Vec<IndividualT>,
         children: Vec<IndividualT>,
     ) -> Vec<IndividualT> {
@@ -73,7 +73,7 @@ impl<IndividualT: IndividualTrait> ReplacementOperator<IndividualT> for Noop {
     #[inline(always)]
     fn apply(
         &mut self,
-        _metadata: &Metrics,
+        _metrics: &Metrics,
         population: Vec<IndividualT>,
         _children: Vec<IndividualT>,
     ) -> Vec<IndividualT> {
@@ -141,7 +141,7 @@ impl<IndividualT: IndividualTrait> ReplacementOperator<IndividualT> for WeakPare
     /// * `children` - Result of the crossover phase
     fn apply(
         &mut self,
-        _metadata: &Metrics,
+        _metrics: &Metrics,
         mut population: Vec<IndividualT>,
         mut children: Vec<IndividualT>,
     ) -> Vec<IndividualT> {

--- a/src/ga/operators/replacement/impls.rs
+++ b/src/ga/operators/replacement/impls.rs
@@ -182,7 +182,7 @@ impl<IndividualT: IndividualTrait> ReplacementOperator<IndividualT> for WeakPare
 
 #[cfg(test)]
 mod tests {
-    use crate::ga::{Metrics, Individual};
+    use crate::ga::{Individual, Metrics};
 
     use super::{BothParents, Noop, ReplacementOperator, WeakParent};
 

--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -3,7 +3,7 @@ pub mod impls;
 #[cfg(feature = "ga_impl_selection")]
 pub use impls::*;
 
-use crate::ga::{individual::IndividualTrait, GAMetadata};
+use crate::ga::{individual::IndividualTrait, Metrics};
 
 /// ### Selection operator
 ///
@@ -31,7 +31,7 @@ pub trait SelectionOperator<IndividualT: IndividualTrait> {
     /// * `count` - target number of individuals in mating pool
     fn apply<'a>(
         &mut self,
-        metadata: &GAMetadata,
+        metadata: &Metrics,
         population: &'a [IndividualT],
         count: usize,
     ) -> Vec<&'a IndividualT>;

--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -26,12 +26,12 @@ pub trait SelectionOperator<IndividualT: IndividualTrait> {
     ///
     /// ### Arguments
     ///
-    /// * `metadata` - [crate::ga::GAMetadata] information on current stage of the algorithm (iteration, elapsed time, etc.)
+    /// * `metrics` - [crate::ga::Metrics] information on current stage of the algorithm (iteration, elapsed time, etc.)
     /// * `population` - individuals to choose mating pool from
     /// * `count` - target number of individuals in mating pool
     fn apply<'a>(
         &mut self,
-        metadata: &Metrics,
+        metrics: &Metrics,
         population: &'a [IndividualT],
         count: usize,
     ) -> Vec<&'a IndividualT>;

--- a/src/ga/operators/selection/impls.rs
+++ b/src/ga/operators/selection/impls.rs
@@ -58,12 +58,12 @@ where
     ///
     /// ### Arguments
     ///
-    /// * `metadata` - [crate::ga::GAMetadata] information on current stage of the algorithm (iteration, elapsed time, etc.)
+    /// * `metrics` - [crate::ga::Metrics] information on current stage of the algorithm (iteration, elapsed time, etc.)
     /// * `population` - individuals to choose mating pool from
     /// * `count` - target number of individuals in mating pool
     fn apply<'a>(
         &mut self,
-        _metadata: &Metrics,
+        _metrics: &Metrics,
         population: &'a [IndividualT],
         count: usize,
     ) -> Vec<&'a IndividualT> {
@@ -122,12 +122,12 @@ impl<IndividualT: IndividualTrait, R: Rng> SelectionOperator<IndividualT> for Ra
     ///
     /// ### Arguments
     ///
-    /// * `metadata` - [crate::ga::GAMetadata] information on current stage of the algorithm (iteration, elapsed time, etc.)
+    /// * `metrics` - [crate::ga::Metrics] information on current stage of the algorithm (iteration, elapsed time, etc.)
     /// * `population` - individuals to choose mating pool from
     /// * `count` - target number of individuals in mating pool
     fn apply<'a>(
         &mut self,
-        _metadata: &Metrics,
+        _metrics: &Metrics,
         population: &'a [IndividualT],
         count: usize,
     ) -> Vec<&'a IndividualT> {
@@ -181,12 +181,12 @@ where
     ///
     /// ### Arguments
     ///
-    /// * `metadata` - [crate::ga::GAMetadata] information on current stage of the algorithm (iteration, elapsed time, etc.)
+    /// * `metrics` - [crate::ga::Metrics] information on current stage of the algorithm (iteration, elapsed time, etc.)
     /// * `population` - individuals to choose mating pool from
     /// * `count` - target number of individuals in mating pool
     fn apply<'a>(
         &mut self,
-        _metadata: &Metrics,
+        _metrics: &Metrics,
         population: &'a [IndividualT],
         count: usize,
     ) -> Vec<&'a IndividualT> {
@@ -261,12 +261,12 @@ impl<IndividualT: IndividualTrait, R: Rng> SelectionOperator<IndividualT> for Ra
     ///
     /// ### Arguments
     ///
-    /// * `metadata` - [crate::ga::GAMetadata] information on current stage of the algorithm (iteration, elapsed time, etc.)
+    /// * `metrics` - [crate::ga::Metrics] information on current stage of the algorithm (iteration, elapsed time, etc.)
     /// * `population` - individuals to choose mating pool from
     /// * `count` - target number of individuals in mating pool
     fn apply<'a>(
         &mut self,
-        _metadata: &Metrics,
+        _metrics: &Metrics,
         population: &'a [IndividualT],
         count: usize,
     ) -> Vec<&'a IndividualT> {
@@ -343,12 +343,12 @@ impl<IndividualT: IndividualTrait, R: Rng> SelectionOperator<IndividualT> for To
     ///
     /// ### Arguments
     ///
-    /// * `metadata` - [crate::ga::GAMetadata] information on current stage of the algorithm (iteration, elapsed time, etc.)
+    /// * `metrics` - [crate::ga::Metrics] information on current stage of the algorithm (iteration, elapsed time, etc.)
     /// * `population` - individuals to choose mating pool from
     /// * `count` - target number of individuals in mating pool
     fn apply<'a>(
         &mut self,
-        _metadata: &Metrics,
+        _metrics: &Metrics,
         population: &'a [IndividualT],
         count: usize,
     ) -> Vec<&'a IndividualT> {
@@ -439,12 +439,12 @@ impl<IndividualT: IndividualTrait<FitnessValueT = f64>, R: Rng> SelectionOperato
     ///
     /// ### Arguments
     ///
-    /// * `metadata` - [crate::ga::GAMetadata] information on current stage of the algorithm (iteration, elapsed time, etc.)
+    /// * `metrics` - [crate::ga::Metrics] information on current stage of the algorithm (iteration, elapsed time, etc.)
     /// * `population` - individuals to choose mating pool from
     /// * `count` - target number of individuals in mating pool
     fn apply<'a>(
         &mut self,
-        _metadata: &Metrics,
+        _metrics: &Metrics,
         population: &'a [IndividualT],
         count: usize,
     ) -> Vec<&'a IndividualT> {
@@ -538,14 +538,14 @@ where
 {
     fn apply<'a>(
         &mut self,
-        metadata: &Metrics,
+        metrics: &Metrics,
         population: &'a [IndividualT],
         count: usize,
     ) -> Vec<&'a IndividualT> {
         let mut selected: Vec<&IndividualT> = Vec::with_capacity(count);
         let mut weights: Vec<f64> = Vec::with_capacity(count);
 
-        let k = 1.0 + 100.0 * (metadata.generation as f64) / (self.max_gen_count as f64);
+        let k = 1.0 + 100.0 * (metrics.generation as f64) / (self.max_gen_count as f64);
         let temp = self.temp_0 * (1.0 - self.alpha).powf(k);
 
         for idv in population {

--- a/src/ga/operators/selection/impls.rs
+++ b/src/ga/operators/selection/impls.rs
@@ -3,7 +3,7 @@ use std::{iter::Sum, ops::Index};
 use num_traits::{identities::Zero, NumAssignOps};
 use rand::{distributions::Standard, prelude::Distribution, rngs::ThreadRng, Rng};
 
-use crate::ga::{individual::IndividualTrait, GAMetadata};
+use crate::ga::{individual::IndividualTrait, Metrics};
 
 use super::SelectionOperator;
 
@@ -63,7 +63,7 @@ where
     /// * `count` - target number of individuals in mating pool
     fn apply<'a>(
         &mut self,
-        _metadata: &GAMetadata,
+        _metadata: &Metrics,
         population: &'a [IndividualT],
         count: usize,
     ) -> Vec<&'a IndividualT> {
@@ -127,7 +127,7 @@ impl<IndividualT: IndividualTrait, R: Rng> SelectionOperator<IndividualT> for Ra
     /// * `count` - target number of individuals in mating pool
     fn apply<'a>(
         &mut self,
-        _metadata: &GAMetadata,
+        _metadata: &Metrics,
         population: &'a [IndividualT],
         count: usize,
     ) -> Vec<&'a IndividualT> {
@@ -186,7 +186,7 @@ where
     /// * `count` - target number of individuals in mating pool
     fn apply<'a>(
         &mut self,
-        _metadata: &GAMetadata,
+        _metadata: &Metrics,
         population: &'a [IndividualT],
         count: usize,
     ) -> Vec<&'a IndividualT> {
@@ -266,7 +266,7 @@ impl<IndividualT: IndividualTrait, R: Rng> SelectionOperator<IndividualT> for Ra
     /// * `count` - target number of individuals in mating pool
     fn apply<'a>(
         &mut self,
-        _metadata: &GAMetadata,
+        _metadata: &Metrics,
         population: &'a [IndividualT],
         count: usize,
     ) -> Vec<&'a IndividualT> {
@@ -348,7 +348,7 @@ impl<IndividualT: IndividualTrait, R: Rng> SelectionOperator<IndividualT> for To
     /// * `count` - target number of individuals in mating pool
     fn apply<'a>(
         &mut self,
-        _metadata: &GAMetadata,
+        _metadata: &Metrics,
         population: &'a [IndividualT],
         count: usize,
     ) -> Vec<&'a IndividualT> {
@@ -444,7 +444,7 @@ impl<IndividualT: IndividualTrait<FitnessValueT = f64>, R: Rng> SelectionOperato
     /// * `count` - target number of individuals in mating pool
     fn apply<'a>(
         &mut self,
-        _metadata: &GAMetadata,
+        _metadata: &Metrics,
         population: &'a [IndividualT],
         count: usize,
     ) -> Vec<&'a IndividualT> {
@@ -538,7 +538,7 @@ where
 {
     fn apply<'a>(
         &mut self,
-        metadata: &GAMetadata,
+        metadata: &Metrics,
         population: &'a [IndividualT],
         count: usize,
     ) -> Vec<&'a IndividualT> {

--- a/src/ga/probe.rs
+++ b/src/ga/probe.rs
@@ -116,12 +116,8 @@ pub trait Probe<IndividualT: IndividualTrait> {
     /// See [GAMetadata] for reference.
     /// * `population` - Final population
     /// * `best_individual` - Best individual found by algorithm
-    fn on_end(
-        &mut self,
-        _metadata: &Metrics,
-        _population: &[IndividualT],
-        _best_individual: &IndividualT,
-    ) { /* defaults to noop */
+    fn on_end(&mut self, _metadata: &Metrics, _population: &[IndividualT], _best_individual: &IndividualT) {
+        /* defaults to noop */
     }
 }
 

--- a/src/ga/probe.rs
+++ b/src/ga/probe.rs
@@ -27,10 +27,10 @@ pub trait Probe<IndividualT: IndividualTrait> {
     ///
     /// ### Arguments
     ///
-    /// * `metadata` - Structure containing metadata information on genetic algorithm.
-    /// See [GAMetadata] for reference. When running this method only `start_time`
+    /// * `metrics` - Structure containing metrics information on genetic algorithm.
+    /// See [Metrics] for reference. When running this method only `start_time`
     /// field has meaningful value.
-    fn on_start(&mut self, _metadata: &Metrics) { /* defaults to noop */
+    fn on_start(&mut self, _metrics: &Metrics) { /* defaults to noop */
     }
 
     /// This method is called directly after initial populationn is created and fitness
@@ -41,7 +41,7 @@ pub trait Probe<IndividualT: IndividualTrait> {
     /// ### Arguments
     ///
     /// * `population` - Freshly generated population
-    fn on_initial_population_created(&mut self, _metadata: &Metrics, _population: &[IndividualT]) {
+    fn on_initial_population_created(&mut self, _metrics: &Metrics, _population: &[IndividualT]) {
         /* defaults to noop */
     }
 
@@ -51,10 +51,10 @@ pub trait Probe<IndividualT: IndividualTrait> {
     ///
     /// ### Arguments
     ///
-    /// * `metadata` - Structure containing metadata information on genetic algorithm.
-    /// See [GAMetadata] for reference.
+    /// * `metrics` - Structure containing metrics information on genetic algorithm.
+    /// See [Metrics] for reference.
     /// * `individual` - New best individual
-    fn on_new_best(&mut self, _metadata: &Metrics, _individual: &IndividualT) {
+    fn on_new_best(&mut self, _metrics: &Metrics, _individual: &IndividualT) {
         /* defaults to noop */
     }
 
@@ -64,10 +64,10 @@ pub trait Probe<IndividualT: IndividualTrait> {
     ///
     /// ### Arguments
     ///
-    /// * `metadata` - Structure containing metadata information on genetic algorithm.
-    /// See [GAMetadata] for reference.
+    /// * `metrics` - Structure containing metrics information on genetic algorithm.
+    /// See [Metrics] for reference.
     /// * `generation` - Newly created generation
-    fn on_new_generation(&mut self, _metadata: &Metrics, _generation: &[IndividualT]) {
+    fn on_new_generation(&mut self, _metrics: &Metrics, _generation: &[IndividualT]) {
         /* defaults to noop */
     }
 
@@ -77,10 +77,10 @@ pub trait Probe<IndividualT: IndividualTrait> {
     ///
     /// ### Arguments
     ///
-    /// * `metadata` - Structure containing metadata information on genetic algorithm.
-    /// See [GAMetadata] for reference.
+    /// * `metrics` - Structure containing metrics information on genetic algorithm.
+    /// See [Metrics] for reference.
     /// * `individual` - Best individual in current generation
-    fn on_best_fit_in_generation(&mut self, _metadata: &Metrics, _individual: &IndividualT) {
+    fn on_best_fit_in_generation(&mut self, _metrics: &Metrics, _individual: &IndividualT) {
         /* defaults to noop */
     }
 
@@ -90,9 +90,9 @@ pub trait Probe<IndividualT: IndividualTrait> {
     ///
     /// ### Arguments
     ///
-    /// * `metadata` - Structure containing metadata information on genetic algorithm.
-    /// See [GAMetadata] for reference.
-    fn on_iteration_start(&mut self, _metadata: &Metrics) { /* defaults to noop */
+    /// * `metrics` - Structure containing metrics information on genetic algorithm.
+    /// See [Metrics] for reference.
+    fn on_iteration_start(&mut self, _metrics: &Metrics) { /* defaults to noop */
     }
 
     /// This method is called in the very end of algorithm's main loop, just before
@@ -100,9 +100,9 @@ pub trait Probe<IndividualT: IndividualTrait> {
     ///
     /// ### Arguments
     ///
-    /// * `metadata` - Structure containing metadata information on genetic algorithm.
-    /// See [GAMetadata] for reference.
-    fn on_iteration_end(&mut self, _metadata: &Metrics) { /* defaults to noop */
+    /// * `metrics` - Structure containing metrics information on genetic algorithm.
+    /// See [Metrics] for reference.
+    fn on_iteration_end(&mut self, _metrics: &Metrics) { /* defaults to noop */
     }
 
     /// This method is called after algorithm 's main loop is exited, just before the `run`
@@ -112,11 +112,11 @@ pub trait Probe<IndividualT: IndividualTrait> {
     ///
     /// ### Arguments
     ///
-    /// * `metadata` - Structure containing metadata information on genetic algorithm.
-    /// See [GAMetadata] for reference.
+    /// * `metrics` - Structure containing metrics information on genetic algorithm.
+    /// See [Metrics] for reference.
     /// * `population` - Final population
     /// * `best_individual` - Best individual found by algorithm
-    fn on_end(&mut self, _metadata: &Metrics, _population: &[IndividualT], _best_individual: &IndividualT) {
+    fn on_end(&mut self, _metrics: &Metrics, _population: &[IndividualT], _best_individual: &IndividualT) {
         /* defaults to noop */
     }
 }
@@ -135,48 +135,48 @@ pub trait Probe<IndividualT: IndividualTrait> {
 ///
 /// ```
 /// # use ecrs::ga::individual::IndividualTrait;
-/// # use ecrs::ga::GAMetadata;
+/// # use ecrs::ga::Metrics;
 /// # use ecrs::ga::probe::ProbingPolicy;
 ///
 /// struct EvenIteration;
 ///
 /// impl<IndividualT: IndividualTrait> ProbingPolicy<IndividualT> for EvenIteration {
-///   fn on_start(&mut self, _metadata: &GAMetadata) -> bool {
+///   fn on_start(&mut self, _metrics: &Metrics) -> bool {
 ///     // We want to always log on start
 ///     true
 ///   }
 ///
-///   fn on_initial_population_created(&mut self, _metadata: &GAMetadata,  _population: &[IndividualT]) -> bool {
+///   fn on_initial_population_created(&mut self, _metrics: &Metrics,  _population: &[IndividualT]) -> bool {
 ///     // We want to log initial population
 ///     true
 ///   }
 ///
-///   fn on_new_best(&mut self, _metadata: &GAMetadata, _individual: &IndividualT) -> bool {
+///   fn on_new_best(&mut self, _metrics: &Metrics, _individual: &IndividualT) -> bool {
 ///     // We want to see when algorithm improves
 ///     true
 ///   }
 ///
-///   fn on_new_generation(&mut self, metadata: &GAMetadata, _generation: &[IndividualT]) -> bool {
+///   fn on_new_generation(&mut self, metrics: &Metrics, _generation: &[IndividualT]) -> bool {
 ///     // Only on even iterations
-///     metadata.generation % 2 == 0
+///     metrics.generation % 2 == 0
 ///   }
 ///
-///   fn on_best_fit_in_generation(&mut self, metadata: &GAMetadata, _individual: &IndividualT) -> bool {
+///   fn on_best_fit_in_generation(&mut self, metrics: &Metrics, _individual: &IndividualT) -> bool {
 ///     // Only on even iterations
-///     metadata.generation % 2 == 0
+///     metrics.generation % 2 == 0
 ///   }
 ///
-///   fn on_iteration_start(&mut self, metadata: &GAMetadata) -> bool {
-///     metadata.generation % 2 == 0
+///   fn on_iteration_start(&mut self, metrics: &Metrics) -> bool {
+///     metrics.generation % 2 == 0
 ///   }
 ///
-///   fn on_iteration_end(&mut self, metadata: &GAMetadata) -> bool {
-///     metadata.generation % 2 == 0
+///   fn on_iteration_end(&mut self, metrics: &Metrics) -> bool {
+///     metrics.generation % 2 == 0
 ///   }
 ///
 ///   fn on_end(
 ///     &mut self,
-///     _metadata: &GAMetadata,
+///     _metrics: &Metrics,
 ///     _population: &[IndividualT],
 ///     _best_individual: &IndividualT,
 ///   ) -> bool {
@@ -188,16 +188,16 @@ pub trait Probe<IndividualT: IndividualTrait> {
 ///
 /// Later you can use it with [PolicyDrivenProbe]
 pub trait ProbingPolicy<IndividualT: IndividualTrait> {
-    fn on_start(&mut self, _metadata: &Metrics) -> bool;
-    fn on_initial_population_created(&mut self, _metadata: &Metrics, _population: &[IndividualT]) -> bool;
-    fn on_new_best(&mut self, _metadata: &Metrics, _individual: &IndividualT) -> bool;
-    fn on_new_generation(&mut self, _metadata: &Metrics, _generation: &[IndividualT]) -> bool;
-    fn on_best_fit_in_generation(&mut self, _metadata: &Metrics, _individual: &IndividualT) -> bool;
-    fn on_iteration_start(&mut self, _metadata: &Metrics) -> bool;
-    fn on_iteration_end(&mut self, _metadata: &Metrics) -> bool;
+    fn on_start(&mut self, _metrics: &Metrics) -> bool;
+    fn on_initial_population_created(&mut self, _metrics: &Metrics, _population: &[IndividualT]) -> bool;
+    fn on_new_best(&mut self, _metrics: &Metrics, _individual: &IndividualT) -> bool;
+    fn on_new_generation(&mut self, _metrics: &Metrics, _generation: &[IndividualT]) -> bool;
+    fn on_best_fit_in_generation(&mut self, _metrics: &Metrics, _individual: &IndividualT) -> bool;
+    fn on_iteration_start(&mut self, _metrics: &Metrics) -> bool;
+    fn on_iteration_end(&mut self, _metrics: &Metrics) -> bool;
     fn on_end(
         &mut self,
-        _metadata: &Metrics,
+        _metrics: &Metrics,
         _population: &[IndividualT],
         _best_individual: &IndividualT,
     ) -> bool;

--- a/src/ga/probe.rs
+++ b/src/ga/probe.rs
@@ -1,4 +1,4 @@
-use super::{individual::IndividualTrait, GAMetadata};
+use super::{individual::IndividualTrait, Metrics};
 
 mod aggregated_probe;
 mod csv_probe;
@@ -30,7 +30,7 @@ pub trait Probe<IndividualT: IndividualTrait> {
     /// * `metadata` - Structure containing metadata information on genetic algorithm.
     /// See [GAMetadata] for reference. When running this method only `start_time`
     /// field has meaningful value.
-    fn on_start(&mut self, _metadata: &GAMetadata) { /* defaults to noop */
+    fn on_start(&mut self, _metadata: &Metrics) { /* defaults to noop */
     }
 
     /// This method is called directly after initial populationn is created and fitness
@@ -41,7 +41,7 @@ pub trait Probe<IndividualT: IndividualTrait> {
     /// ### Arguments
     ///
     /// * `population` - Freshly generated population
-    fn on_initial_population_created(&mut self, _metadata: &GAMetadata, _population: &[IndividualT]) {
+    fn on_initial_population_created(&mut self, _metadata: &Metrics, _population: &[IndividualT]) {
         /* defaults to noop */
     }
 
@@ -54,7 +54,7 @@ pub trait Probe<IndividualT: IndividualTrait> {
     /// * `metadata` - Structure containing metadata information on genetic algorithm.
     /// See [GAMetadata] for reference.
     /// * `individual` - New best individual
-    fn on_new_best(&mut self, _metadata: &GAMetadata, _individual: &IndividualT) {
+    fn on_new_best(&mut self, _metadata: &Metrics, _individual: &IndividualT) {
         /* defaults to noop */
     }
 
@@ -67,7 +67,7 @@ pub trait Probe<IndividualT: IndividualTrait> {
     /// * `metadata` - Structure containing metadata information on genetic algorithm.
     /// See [GAMetadata] for reference.
     /// * `generation` - Newly created generation
-    fn on_new_generation(&mut self, _metadata: &GAMetadata, _generation: &[IndividualT]) {
+    fn on_new_generation(&mut self, _metadata: &Metrics, _generation: &[IndividualT]) {
         /* defaults to noop */
     }
 
@@ -80,7 +80,7 @@ pub trait Probe<IndividualT: IndividualTrait> {
     /// * `metadata` - Structure containing metadata information on genetic algorithm.
     /// See [GAMetadata] for reference.
     /// * `individual` - Best individual in current generation
-    fn on_best_fit_in_generation(&mut self, _metadata: &GAMetadata, _individual: &IndividualT) {
+    fn on_best_fit_in_generation(&mut self, _metadata: &Metrics, _individual: &IndividualT) {
         /* defaults to noop */
     }
 
@@ -92,7 +92,7 @@ pub trait Probe<IndividualT: IndividualTrait> {
     ///
     /// * `metadata` - Structure containing metadata information on genetic algorithm.
     /// See [GAMetadata] for reference.
-    fn on_iteration_start(&mut self, _metadata: &GAMetadata) { /* defaults to noop */
+    fn on_iteration_start(&mut self, _metadata: &Metrics) { /* defaults to noop */
     }
 
     /// This method is called in the very end of algorithm's main loop, just before
@@ -102,7 +102,7 @@ pub trait Probe<IndividualT: IndividualTrait> {
     ///
     /// * `metadata` - Structure containing metadata information on genetic algorithm.
     /// See [GAMetadata] for reference.
-    fn on_iteration_end(&mut self, _metadata: &GAMetadata) { /* defaults to noop */
+    fn on_iteration_end(&mut self, _metadata: &Metrics) { /* defaults to noop */
     }
 
     /// This method is called after algorithm 's main loop is exited, just before the `run`
@@ -118,7 +118,7 @@ pub trait Probe<IndividualT: IndividualTrait> {
     /// * `best_individual` - Best individual found by algorithm
     fn on_end(
         &mut self,
-        _metadata: &GAMetadata,
+        _metadata: &Metrics,
         _population: &[IndividualT],
         _best_individual: &IndividualT,
     ) { /* defaults to noop */
@@ -192,16 +192,16 @@ pub trait Probe<IndividualT: IndividualTrait> {
 ///
 /// Later you can use it with [PolicyDrivenProbe]
 pub trait ProbingPolicy<IndividualT: IndividualTrait> {
-    fn on_start(&mut self, _metadata: &GAMetadata) -> bool;
-    fn on_initial_population_created(&mut self, _metadata: &GAMetadata, _population: &[IndividualT]) -> bool;
-    fn on_new_best(&mut self, _metadata: &GAMetadata, _individual: &IndividualT) -> bool;
-    fn on_new_generation(&mut self, _metadata: &GAMetadata, _generation: &[IndividualT]) -> bool;
-    fn on_best_fit_in_generation(&mut self, _metadata: &GAMetadata, _individual: &IndividualT) -> bool;
-    fn on_iteration_start(&mut self, _metadata: &GAMetadata) -> bool;
-    fn on_iteration_end(&mut self, _metadata: &GAMetadata) -> bool;
+    fn on_start(&mut self, _metadata: &Metrics) -> bool;
+    fn on_initial_population_created(&mut self, _metadata: &Metrics, _population: &[IndividualT]) -> bool;
+    fn on_new_best(&mut self, _metadata: &Metrics, _individual: &IndividualT) -> bool;
+    fn on_new_generation(&mut self, _metadata: &Metrics, _generation: &[IndividualT]) -> bool;
+    fn on_best_fit_in_generation(&mut self, _metadata: &Metrics, _individual: &IndividualT) -> bool;
+    fn on_iteration_start(&mut self, _metadata: &Metrics) -> bool;
+    fn on_iteration_end(&mut self, _metadata: &Metrics) -> bool;
     fn on_end(
         &mut self,
-        _metadata: &GAMetadata,
+        _metadata: &Metrics,
         _population: &[IndividualT],
         _best_individual: &IndividualT,
     ) -> bool;

--- a/src/ga/probe/aggregated_probe.rs
+++ b/src/ga/probe/aggregated_probe.rs
@@ -46,12 +46,12 @@ impl<IndividualT: IndividualTrait> Probe<IndividualT> for AggregatedProbe<Indivi
     ///
     /// ### Arguments
     ///
-    /// * `metadata` - Structure containing metadata information on genetic algorithm.
-    /// See [GAMetadata] for reference. When running this method only `start_time`
+    /// * `metrics` - Structure containing metrics information on genetic algorithm.
+    /// See [Metrics] for reference. When running this method only `start_time`
     /// field has meaningful value.
-    fn on_start(&mut self, metadata: &Metrics) {
+    fn on_start(&mut self, metrics: &Metrics) {
         for probe in &mut self.probes {
-            probe.on_start(metadata);
+            probe.on_start(metrics);
         }
     }
 
@@ -63,9 +63,9 @@ impl<IndividualT: IndividualTrait> Probe<IndividualT> for AggregatedProbe<Indivi
     /// ### Arguments
     ///
     /// * `population` - Freshly generated population
-    fn on_initial_population_created(&mut self, metadata: &Metrics, population: &[IndividualT]) {
+    fn on_initial_population_created(&mut self, metrics: &Metrics, population: &[IndividualT]) {
         for probe in &mut self.probes {
-            probe.on_initial_population_created(metadata, population);
+            probe.on_initial_population_created(metrics, population);
         }
     }
 
@@ -75,12 +75,12 @@ impl<IndividualT: IndividualTrait> Probe<IndividualT> for AggregatedProbe<Indivi
     ///
     /// ### Arguments
     ///
-    /// * `metadata` - Structure containing metadata information on genetic algorithm.
-    /// See [GAMetadata] for reference.
+    /// * `Metrics` - Structure containing Metrics information on genetic algorithm.
+    /// See [Metrics] for reference.
     /// * `individual` - New best individual
-    fn on_new_best(&mut self, metadata: &Metrics, individual: &IndividualT) {
+    fn on_new_best(&mut self, metrics: &Metrics, individual: &IndividualT) {
         for probe in &mut self.probes {
-            probe.on_new_best(metadata, individual);
+            probe.on_new_best(metrics, individual);
         }
     }
 
@@ -91,10 +91,10 @@ impl<IndividualT: IndividualTrait> Probe<IndividualT> for AggregatedProbe<Indivi
     /// ### Arguments
     ///
     /// * `generation` - Newly created generation
-    fn on_new_generation(&mut self, metadata: &Metrics, generation: &[IndividualT]) {
+    fn on_new_generation(&mut self, metrics: &Metrics, generation: &[IndividualT]) {
         /* defaults to noop */
         for probe in &mut self.probes {
-            probe.on_new_generation(metadata, generation);
+            probe.on_new_generation(metrics, generation);
         }
     }
 
@@ -104,12 +104,12 @@ impl<IndividualT: IndividualTrait> Probe<IndividualT> for AggregatedProbe<Indivi
     ///
     /// ### Arguments
     ///
-    /// * `metadata` - Structure containing metadata information on genetic algorithm.
-    /// See [GAMetadata] for reference.
+    /// * `metrics` - Structure containing metrics information on genetic algorithm.
+    /// See [Metrics] for reference.
     /// * `individual` - Best individual in current generation
-    fn on_best_fit_in_generation(&mut self, metadata: &Metrics, individual: &IndividualT) {
+    fn on_best_fit_in_generation(&mut self, metrics: &Metrics, individual: &IndividualT) {
         for probe in &mut self.probes {
-            probe.on_best_fit_in_generation(metadata, individual);
+            probe.on_best_fit_in_generation(metrics, individual);
         }
     }
 
@@ -119,12 +119,12 @@ impl<IndividualT: IndividualTrait> Probe<IndividualT> for AggregatedProbe<Indivi
     ///
     /// ### Arguments
     ///
-    /// * `metadata` - Structure containing metadata information on genetic algorithm.
-    /// See [GAMetadata] for reference.
-    fn on_iteration_start(&mut self, metadata: &Metrics) {
+    /// * `metrics` - Structure containing metrics information on genetic algorithm.
+    /// See [Metrics] for reference.
+    fn on_iteration_start(&mut self, metrics: &Metrics) {
         /* defaults to noop */
         for probe in &mut self.probes {
-            probe.on_iteration_start(metadata);
+            probe.on_iteration_start(metrics);
         }
     }
 
@@ -135,12 +135,12 @@ impl<IndividualT: IndividualTrait> Probe<IndividualT> for AggregatedProbe<Indivi
     ///
     /// ### Arguments
     ///
-    /// * `metadata` - Structure containing metadata information on genetic algorithm.
-    /// See [GAMetadata] for reference.
-    fn on_iteration_end(&mut self, metadata: &Metrics) {
+    /// * `metrics` - Structure containing metrics information on genetic algorithm.
+    /// See [Metrics] for reference.
+    fn on_iteration_end(&mut self, metrics: &Metrics) {
         /* defaults to noop */
         for probe in &mut self.probes {
-            probe.on_iteration_end(metadata);
+            probe.on_iteration_end(metrics);
         }
     }
 
@@ -151,13 +151,13 @@ impl<IndividualT: IndividualTrait> Probe<IndividualT> for AggregatedProbe<Indivi
     ///
     /// ### Arguments
     ///
-    /// * `metadata` - Structure containing metadata information on genetic algorithm.
-    /// See [GAMetadata] for reference.
+    /// * `metrics` - Structure containing metrics information on genetic algorithm.
+    /// See [Metrics] for reference.
     /// * `population` - Final population
     /// * `best_individual` - Best individual found by algorithm
-    fn on_end(&mut self, metadata: &Metrics, population: &[IndividualT], best_individual: &IndividualT) {
+    fn on_end(&mut self, metrics: &Metrics, population: &[IndividualT], best_individual: &IndividualT) {
         for probe in &mut self.probes {
-            probe.on_end(metadata, population, best_individual);
+            probe.on_end(metrics, population, best_individual);
         }
     }
 }

--- a/src/ga/probe/aggregated_probe.rs
+++ b/src/ga/probe/aggregated_probe.rs
@@ -1,5 +1,5 @@
 use super::Probe;
-use crate::ga::{individual::IndividualTrait, GAMetadata};
+use crate::ga::{individual::IndividualTrait, Metrics};
 
 /// Wrapper probe. It holds a list of probes and calls them sequentially.
 ///
@@ -49,7 +49,7 @@ impl<IndividualT: IndividualTrait> Probe<IndividualT> for AggregatedProbe<Indivi
     /// * `metadata` - Structure containing metadata information on genetic algorithm.
     /// See [GAMetadata] for reference. When running this method only `start_time`
     /// field has meaningful value.
-    fn on_start(&mut self, metadata: &GAMetadata) {
+    fn on_start(&mut self, metadata: &Metrics) {
         for probe in &mut self.probes {
             probe.on_start(metadata);
         }
@@ -63,7 +63,7 @@ impl<IndividualT: IndividualTrait> Probe<IndividualT> for AggregatedProbe<Indivi
     /// ### Arguments
     ///
     /// * `population` - Freshly generated population
-    fn on_initial_population_created(&mut self, metadata: &GAMetadata, population: &[IndividualT]) {
+    fn on_initial_population_created(&mut self, metadata: &Metrics, population: &[IndividualT]) {
         for probe in &mut self.probes {
             probe.on_initial_population_created(metadata, population);
         }
@@ -78,7 +78,7 @@ impl<IndividualT: IndividualTrait> Probe<IndividualT> for AggregatedProbe<Indivi
     /// * `metadata` - Structure containing metadata information on genetic algorithm.
     /// See [GAMetadata] for reference.
     /// * `individual` - New best individual
-    fn on_new_best(&mut self, metadata: &GAMetadata, individual: &IndividualT) {
+    fn on_new_best(&mut self, metadata: &Metrics, individual: &IndividualT) {
         for probe in &mut self.probes {
             probe.on_new_best(metadata, individual);
         }
@@ -91,7 +91,7 @@ impl<IndividualT: IndividualTrait> Probe<IndividualT> for AggregatedProbe<Indivi
     /// ### Arguments
     ///
     /// * `generation` - Newly created generation
-    fn on_new_generation(&mut self, metadata: &GAMetadata, generation: &[IndividualT]) {
+    fn on_new_generation(&mut self, metadata: &Metrics, generation: &[IndividualT]) {
         /* defaults to noop */
         for probe in &mut self.probes {
             probe.on_new_generation(metadata, generation);
@@ -107,7 +107,7 @@ impl<IndividualT: IndividualTrait> Probe<IndividualT> for AggregatedProbe<Indivi
     /// * `metadata` - Structure containing metadata information on genetic algorithm.
     /// See [GAMetadata] for reference.
     /// * `individual` - Best individual in current generation
-    fn on_best_fit_in_generation(&mut self, metadata: &GAMetadata, individual: &IndividualT) {
+    fn on_best_fit_in_generation(&mut self, metadata: &Metrics, individual: &IndividualT) {
         for probe in &mut self.probes {
             probe.on_best_fit_in_generation(metadata, individual);
         }
@@ -121,7 +121,7 @@ impl<IndividualT: IndividualTrait> Probe<IndividualT> for AggregatedProbe<Indivi
     ///
     /// * `metadata` - Structure containing metadata information on genetic algorithm.
     /// See [GAMetadata] for reference.
-    fn on_iteration_start(&mut self, metadata: &GAMetadata) {
+    fn on_iteration_start(&mut self, metadata: &Metrics) {
         /* defaults to noop */
         for probe in &mut self.probes {
             probe.on_iteration_start(metadata);
@@ -137,7 +137,7 @@ impl<IndividualT: IndividualTrait> Probe<IndividualT> for AggregatedProbe<Indivi
     ///
     /// * `metadata` - Structure containing metadata information on genetic algorithm.
     /// See [GAMetadata] for reference.
-    fn on_iteration_end(&mut self, metadata: &GAMetadata) {
+    fn on_iteration_end(&mut self, metadata: &Metrics) {
         /* defaults to noop */
         for probe in &mut self.probes {
             probe.on_iteration_end(metadata);
@@ -155,7 +155,7 @@ impl<IndividualT: IndividualTrait> Probe<IndividualT> for AggregatedProbe<Indivi
     /// See [GAMetadata] for reference.
     /// * `population` - Final population
     /// * `best_individual` - Best individual found by algorithm
-    fn on_end(&mut self, metadata: &GAMetadata, population: &[IndividualT], best_individual: &IndividualT) {
+    fn on_end(&mut self, metadata: &Metrics, population: &[IndividualT], best_individual: &IndividualT) {
         for probe in &mut self.probes {
             probe.on_end(metadata, population, best_individual);
         }

--- a/src/ga/probe/policy_driven_probe.rs
+++ b/src/ga/probe/policy_driven_probe.rs
@@ -45,12 +45,12 @@ impl<IndividualT: IndividualTrait, Pc: ProbingPolicy<IndividualT>, Pr: Probe<Ind
     ///
     /// ### Arguments
     ///
-    /// * `metadata` - Structure containing metadata information on genetic algorithm.
-    /// See [GAMetadata] for reference. When running this method only `start_time`
+    /// * `metrics` - Structure containing metrics information on genetic algorithm.
+    /// See [Metrics] for reference. When running this method only `start_time`
     /// field has meaningful value.
-    fn on_start(&mut self, metadata: &Metrics) {
-        if self.policy.on_start(metadata) {
-            self.probe.on_start(metadata);
+    fn on_start(&mut self, metrics: &Metrics) {
+        if self.policy.on_start(metrics) {
+            self.probe.on_start(metrics);
         }
     }
 
@@ -62,9 +62,9 @@ impl<IndividualT: IndividualTrait, Pc: ProbingPolicy<IndividualT>, Pr: Probe<Ind
     /// ### Arguments
     ///
     /// * `population` - Freshly generated population
-    fn on_initial_population_created(&mut self, metadata: &Metrics, population: &[IndividualT]) {
-        if self.policy.on_initial_population_created(metadata, population) {
-            self.probe.on_initial_population_created(metadata, population);
+    fn on_initial_population_created(&mut self, metrics: &Metrics, population: &[IndividualT]) {
+        if self.policy.on_initial_population_created(metrics, population) {
+            self.probe.on_initial_population_created(metrics, population);
         }
     }
 
@@ -74,12 +74,12 @@ impl<IndividualT: IndividualTrait, Pc: ProbingPolicy<IndividualT>, Pr: Probe<Ind
     ///
     /// ### Arguments
     ///
-    /// * `metadata` - Structure containing metadata information on genetic algorithm.
-    /// See [GAMetadata] for reference.
+    /// * `metrics` - Structure containing metrics information on genetic algorithm.
+    /// See [Metrics] for reference.
     /// * `individual` - New best individual
-    fn on_new_best(&mut self, metadata: &Metrics, individual: &IndividualT) {
-        if self.policy.on_new_best(metadata, individual) {
-            self.probe.on_new_best(metadata, individual);
+    fn on_new_best(&mut self, metrics: &Metrics, individual: &IndividualT) {
+        if self.policy.on_new_best(metrics, individual) {
+            self.probe.on_new_best(metrics, individual);
         }
     }
 
@@ -90,9 +90,9 @@ impl<IndividualT: IndividualTrait, Pc: ProbingPolicy<IndividualT>, Pr: Probe<Ind
     /// ### Arguments
     ///
     /// * `generation` - Newly created generation
-    fn on_new_generation(&mut self, metadata: &Metrics, generation: &[IndividualT]) {
-        if self.policy.on_new_generation(metadata, generation) {
-            self.probe.on_new_generation(metadata, generation);
+    fn on_new_generation(&mut self, metrics: &Metrics, generation: &[IndividualT]) {
+        if self.policy.on_new_generation(metrics, generation) {
+            self.probe.on_new_generation(metrics, generation);
         }
     }
 
@@ -102,12 +102,12 @@ impl<IndividualT: IndividualTrait, Pc: ProbingPolicy<IndividualT>, Pr: Probe<Ind
     ///
     /// ### Arguments
     ///
-    /// * `metadata` - Structure containing metadata information on genetic algorithm.
-    /// See [GAMetadata] for reference.
+    /// * `metrics` - Structure containing metrics information on genetic algorithm.
+    /// See [Metrics] for reference.
     /// * `individual` - Best individual in current generation
-    fn on_best_fit_in_generation(&mut self, metadata: &Metrics, individual: &IndividualT) {
-        if self.policy.on_best_fit_in_generation(metadata, individual) {
-            self.probe.on_best_fit_in_generation(metadata, individual);
+    fn on_best_fit_in_generation(&mut self, metrics: &Metrics, individual: &IndividualT) {
+        if self.policy.on_best_fit_in_generation(metrics, individual) {
+            self.probe.on_best_fit_in_generation(metrics, individual);
         }
     }
 
@@ -117,11 +117,11 @@ impl<IndividualT: IndividualTrait, Pc: ProbingPolicy<IndividualT>, Pr: Probe<Ind
     ///
     /// ### Arguments
     ///
-    /// * `metadata` - Structure containing metadata information on genetic algorithm.
-    /// See [GAMetadata] for reference.
-    fn on_iteration_start(&mut self, metadata: &Metrics) {
-        if self.policy.on_iteration_start(metadata) {
-            self.probe.on_iteration_start(metadata);
+    /// * `metrics` - Structure containing metrics information on genetic algorithm.
+    /// See [Metrics] for reference.
+    fn on_iteration_start(&mut self, metrics: &Metrics) {
+        if self.policy.on_iteration_start(metrics) {
+            self.probe.on_iteration_start(metrics);
         }
     }
 
@@ -132,11 +132,11 @@ impl<IndividualT: IndividualTrait, Pc: ProbingPolicy<IndividualT>, Pr: Probe<Ind
     ///
     /// ### Arguments
     ///
-    /// * `metadata` - Structure containing metadata information on genetic algorithm.
-    /// See [GAMetadata] for reference.
-    fn on_iteration_end(&mut self, metadata: &Metrics) {
-        if self.policy.on_iteration_end(metadata) {
-            self.probe.on_iteration_end(metadata);
+    /// * `metrics` - Structure containing metrics information on genetic algorithm.
+    /// See [Metrics] for reference.
+    fn on_iteration_end(&mut self, metrics: &Metrics) {
+        if self.policy.on_iteration_end(metrics) {
+            self.probe.on_iteration_end(metrics);
         }
     }
 
@@ -147,13 +147,13 @@ impl<IndividualT: IndividualTrait, Pc: ProbingPolicy<IndividualT>, Pr: Probe<Ind
     ///
     /// ### Arguments
     ///
-    /// * `metadata` - Structure containing metadata information on genetic algorithm.
-    /// See [GAMetadata] for reference.
+    /// * `metrics` - Structure containing metrics information on genetic algorithm.
+    /// See [Metrics] for reference.
     /// * `population` - Final population
     /// * `best_individual` - Best individual found by algorithm
-    fn on_end(&mut self, metadata: &Metrics, population: &[IndividualT], best_individual: &IndividualT) {
-        if self.policy.on_end(metadata, population, best_individual) {
-            self.probe.on_end(metadata, population, best_individual);
+    fn on_end(&mut self, metrics: &Metrics, population: &[IndividualT], best_individual: &IndividualT) {
+        if self.policy.on_end(metrics, population, best_individual) {
+            self.probe.on_end(metrics, population, best_individual);
         }
     }
 }

--- a/src/ga/probe/policy_driven_probe.rs
+++ b/src/ga/probe/policy_driven_probe.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use crate::ga::{individual::IndividualTrait, GAMetadata};
+use crate::ga::{individual::IndividualTrait, Metrics};
 
 use super::{Probe, ProbingPolicy};
 
@@ -48,7 +48,7 @@ impl<IndividualT: IndividualTrait, Pc: ProbingPolicy<IndividualT>, Pr: Probe<Ind
     /// * `metadata` - Structure containing metadata information on genetic algorithm.
     /// See [GAMetadata] for reference. When running this method only `start_time`
     /// field has meaningful value.
-    fn on_start(&mut self, metadata: &GAMetadata) {
+    fn on_start(&mut self, metadata: &Metrics) {
         if self.policy.on_start(metadata) {
             self.probe.on_start(metadata);
         }
@@ -62,7 +62,7 @@ impl<IndividualT: IndividualTrait, Pc: ProbingPolicy<IndividualT>, Pr: Probe<Ind
     /// ### Arguments
     ///
     /// * `population` - Freshly generated population
-    fn on_initial_population_created(&mut self, metadata: &GAMetadata, population: &[IndividualT]) {
+    fn on_initial_population_created(&mut self, metadata: &Metrics, population: &[IndividualT]) {
         if self.policy.on_initial_population_created(metadata, population) {
             self.probe.on_initial_population_created(metadata, population);
         }
@@ -77,7 +77,7 @@ impl<IndividualT: IndividualTrait, Pc: ProbingPolicy<IndividualT>, Pr: Probe<Ind
     /// * `metadata` - Structure containing metadata information on genetic algorithm.
     /// See [GAMetadata] for reference.
     /// * `individual` - New best individual
-    fn on_new_best(&mut self, metadata: &GAMetadata, individual: &IndividualT) {
+    fn on_new_best(&mut self, metadata: &Metrics, individual: &IndividualT) {
         if self.policy.on_new_best(metadata, individual) {
             self.probe.on_new_best(metadata, individual);
         }
@@ -90,7 +90,7 @@ impl<IndividualT: IndividualTrait, Pc: ProbingPolicy<IndividualT>, Pr: Probe<Ind
     /// ### Arguments
     ///
     /// * `generation` - Newly created generation
-    fn on_new_generation(&mut self, metadata: &GAMetadata, generation: &[IndividualT]) {
+    fn on_new_generation(&mut self, metadata: &Metrics, generation: &[IndividualT]) {
         if self.policy.on_new_generation(metadata, generation) {
             self.probe.on_new_generation(metadata, generation);
         }
@@ -105,7 +105,7 @@ impl<IndividualT: IndividualTrait, Pc: ProbingPolicy<IndividualT>, Pr: Probe<Ind
     /// * `metadata` - Structure containing metadata information on genetic algorithm.
     /// See [GAMetadata] for reference.
     /// * `individual` - Best individual in current generation
-    fn on_best_fit_in_generation(&mut self, metadata: &GAMetadata, individual: &IndividualT) {
+    fn on_best_fit_in_generation(&mut self, metadata: &Metrics, individual: &IndividualT) {
         if self.policy.on_best_fit_in_generation(metadata, individual) {
             self.probe.on_best_fit_in_generation(metadata, individual);
         }
@@ -119,7 +119,7 @@ impl<IndividualT: IndividualTrait, Pc: ProbingPolicy<IndividualT>, Pr: Probe<Ind
     ///
     /// * `metadata` - Structure containing metadata information on genetic algorithm.
     /// See [GAMetadata] for reference.
-    fn on_iteration_start(&mut self, metadata: &GAMetadata) {
+    fn on_iteration_start(&mut self, metadata: &Metrics) {
         if self.policy.on_iteration_start(metadata) {
             self.probe.on_iteration_start(metadata);
         }
@@ -134,7 +134,7 @@ impl<IndividualT: IndividualTrait, Pc: ProbingPolicy<IndividualT>, Pr: Probe<Ind
     ///
     /// * `metadata` - Structure containing metadata information on genetic algorithm.
     /// See [GAMetadata] for reference.
-    fn on_iteration_end(&mut self, metadata: &GAMetadata) {
+    fn on_iteration_end(&mut self, metadata: &Metrics) {
         if self.policy.on_iteration_end(metadata) {
             self.probe.on_iteration_end(metadata);
         }
@@ -151,7 +151,7 @@ impl<IndividualT: IndividualTrait, Pc: ProbingPolicy<IndividualT>, Pr: Probe<Ind
     /// See [GAMetadata] for reference.
     /// * `population` - Final population
     /// * `best_individual` - Best individual found by algorithm
-    fn on_end(&mut self, metadata: &GAMetadata, population: &[IndividualT], best_individual: &IndividualT) {
+    fn on_end(&mut self, metadata: &Metrics, population: &[IndividualT], best_individual: &IndividualT) {
         if self.policy.on_end(metadata, population, best_individual) {
             self.probe.on_end(metadata, population, best_individual);
         }

--- a/src/ga/probe/probing_policy.rs
+++ b/src/ga/probe/probing_policy.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use crate::ga::{individual::IndividualTrait, GAMetadata};
+use crate::ga::{individual::IndividualTrait, Metrics};
 
 use super::ProbingPolicy;
 
@@ -28,36 +28,36 @@ impl GenerationInterval {
 
 impl<IndividualT: IndividualTrait> ProbingPolicy<IndividualT> for GenerationInterval {
     #[inline(always)]
-    fn on_start(&mut self, _metadata: &crate::ga::GAMetadata) -> bool {
+    fn on_start(&mut self, _metadata: &crate::ga::Metrics) -> bool {
         true
     }
 
     #[inline(always)]
-    fn on_initial_population_created(&mut self, _metadata: &GAMetadata, _population: &[IndividualT]) -> bool {
+    fn on_initial_population_created(&mut self, _metadata: &Metrics, _population: &[IndividualT]) -> bool {
         true
     }
 
     #[inline(always)]
-    fn on_new_best(&mut self, _metadata: &crate::ga::GAMetadata, _individual: &IndividualT) -> bool {
+    fn on_new_best(&mut self, _metadata: &crate::ga::Metrics, _individual: &IndividualT) -> bool {
         true
     }
 
     #[inline(always)]
-    fn on_new_generation(&mut self, _metadata: &GAMetadata, _generation: &[IndividualT]) -> bool {
+    fn on_new_generation(&mut self, _metadata: &Metrics, _generation: &[IndividualT]) -> bool {
         self.should_log
     }
 
     #[inline(always)]
     fn on_best_fit_in_generation(
         &mut self,
-        _metadata: &crate::ga::GAMetadata,
+        _metadata: &crate::ga::Metrics,
         _individual: &IndividualT,
     ) -> bool {
         self.should_log
     }
 
     #[inline]
-    fn on_iteration_start(&mut self, metadata: &GAMetadata) -> bool {
+    fn on_iteration_start(&mut self, metadata: &Metrics) -> bool {
         if metadata.generation >= self.threshold {
             self.threshold += self.interval;
             self.should_log = true;
@@ -68,7 +68,7 @@ impl<IndividualT: IndividualTrait> ProbingPolicy<IndividualT> for GenerationInte
     }
 
     #[inline(always)]
-    fn on_iteration_end(&mut self, _metadata: &GAMetadata) -> bool {
+    fn on_iteration_end(&mut self, _metadata: &Metrics) -> bool {
         let prev = self.should_log;
         self.should_log = false;
         prev
@@ -77,7 +77,7 @@ impl<IndividualT: IndividualTrait> ProbingPolicy<IndividualT> for GenerationInte
     #[inline(always)]
     fn on_end(
         &mut self,
-        _metadata: &crate::ga::GAMetadata,
+        _metadata: &crate::ga::Metrics,
         _population: &[IndividualT],
         _best_individual: &IndividualT,
     ) -> bool {
@@ -109,35 +109,35 @@ impl ElapsedTime {
 
 impl<IndividualT: IndividualTrait> ProbingPolicy<IndividualT> for ElapsedTime {
     #[inline(always)]
-    fn on_start(&mut self, _metadata: &crate::ga::GAMetadata) -> bool {
+    fn on_start(&mut self, _metadata: &crate::ga::Metrics) -> bool {
         true
     }
 
     #[inline(always)]
-    fn on_initial_population_created(&mut self, _metadata: &GAMetadata, _population: &[IndividualT]) -> bool {
+    fn on_initial_population_created(&mut self, _metadata: &Metrics, _population: &[IndividualT]) -> bool {
         true
     }
 
     #[inline(always)]
-    fn on_new_best(&mut self, _metadata: &crate::ga::GAMetadata, _individual: &IndividualT) -> bool {
+    fn on_new_best(&mut self, _metadata: &crate::ga::Metrics, _individual: &IndividualT) -> bool {
         true
     }
 
     #[inline(always)]
-    fn on_new_generation(&mut self, _metadata: &GAMetadata, _generation: &[IndividualT]) -> bool {
+    fn on_new_generation(&mut self, _metadata: &Metrics, _generation: &[IndividualT]) -> bool {
         self.should_log
     }
 
     #[inline(always)]
     fn on_best_fit_in_generation(
         &mut self,
-        _metadata: &crate::ga::GAMetadata,
+        _metadata: &crate::ga::Metrics,
         _individual: &IndividualT,
     ) -> bool {
         self.should_log
     }
 
-    fn on_iteration_start(&mut self, metadata: &GAMetadata) -> bool {
+    fn on_iteration_start(&mut self, metadata: &Metrics) -> bool {
         if metadata.total_dur.unwrap() >= self.threshold {
             self.should_log = true;
             self.threshold += self.interval;
@@ -148,7 +148,7 @@ impl<IndividualT: IndividualTrait> ProbingPolicy<IndividualT> for ElapsedTime {
     }
 
     #[inline]
-    fn on_iteration_end(&mut self, _metadata: &GAMetadata) -> bool {
+    fn on_iteration_end(&mut self, _metadata: &Metrics) -> bool {
         let prev = self.should_log;
         self.should_log = false;
         prev
@@ -157,7 +157,7 @@ impl<IndividualT: IndividualTrait> ProbingPolicy<IndividualT> for ElapsedTime {
     #[inline(always)]
     fn on_end(
         &mut self,
-        _metadata: &crate::ga::GAMetadata,
+        _metadata: &crate::ga::Metrics,
         _population: &[IndividualT],
         _best_individual: &IndividualT,
     ) -> bool {

--- a/src/ga/probe/probing_policy.rs
+++ b/src/ga/probe/probing_policy.rs
@@ -28,37 +28,37 @@ impl GenerationInterval {
 
 impl<IndividualT: IndividualTrait> ProbingPolicy<IndividualT> for GenerationInterval {
     #[inline(always)]
-    fn on_start(&mut self, _metadata: &crate::ga::Metrics) -> bool {
+    fn on_start(&mut self, _metrics: &crate::ga::Metrics) -> bool {
         true
     }
 
     #[inline(always)]
-    fn on_initial_population_created(&mut self, _metadata: &Metrics, _population: &[IndividualT]) -> bool {
+    fn on_initial_population_created(&mut self, _metrics: &Metrics, _population: &[IndividualT]) -> bool {
         true
     }
 
     #[inline(always)]
-    fn on_new_best(&mut self, _metadata: &crate::ga::Metrics, _individual: &IndividualT) -> bool {
+    fn on_new_best(&mut self, _metrics: &crate::ga::Metrics, _individual: &IndividualT) -> bool {
         true
     }
 
     #[inline(always)]
-    fn on_new_generation(&mut self, _metadata: &Metrics, _generation: &[IndividualT]) -> bool {
+    fn on_new_generation(&mut self, _metrics: &Metrics, _generation: &[IndividualT]) -> bool {
         self.should_log
     }
 
     #[inline(always)]
     fn on_best_fit_in_generation(
         &mut self,
-        _metadata: &crate::ga::Metrics,
+        _metrics: &crate::ga::Metrics,
         _individual: &IndividualT,
     ) -> bool {
         self.should_log
     }
 
     #[inline]
-    fn on_iteration_start(&mut self, metadata: &Metrics) -> bool {
-        if metadata.generation >= self.threshold {
+    fn on_iteration_start(&mut self, metrics: &Metrics) -> bool {
+        if metrics.generation >= self.threshold {
             self.threshold += self.interval;
             self.should_log = true;
             true
@@ -68,7 +68,7 @@ impl<IndividualT: IndividualTrait> ProbingPolicy<IndividualT> for GenerationInte
     }
 
     #[inline(always)]
-    fn on_iteration_end(&mut self, _metadata: &Metrics) -> bool {
+    fn on_iteration_end(&mut self, _metrics: &Metrics) -> bool {
         let prev = self.should_log;
         self.should_log = false;
         prev
@@ -77,7 +77,7 @@ impl<IndividualT: IndividualTrait> ProbingPolicy<IndividualT> for GenerationInte
     #[inline(always)]
     fn on_end(
         &mut self,
-        _metadata: &crate::ga::Metrics,
+        _metrics: &crate::ga::Metrics,
         _population: &[IndividualT],
         _best_individual: &IndividualT,
     ) -> bool {
@@ -109,36 +109,36 @@ impl ElapsedTime {
 
 impl<IndividualT: IndividualTrait> ProbingPolicy<IndividualT> for ElapsedTime {
     #[inline(always)]
-    fn on_start(&mut self, _metadata: &crate::ga::Metrics) -> bool {
+    fn on_start(&mut self, _metrics: &crate::ga::Metrics) -> bool {
         true
     }
 
     #[inline(always)]
-    fn on_initial_population_created(&mut self, _metadata: &Metrics, _population: &[IndividualT]) -> bool {
+    fn on_initial_population_created(&mut self, _metrics: &Metrics, _population: &[IndividualT]) -> bool {
         true
     }
 
     #[inline(always)]
-    fn on_new_best(&mut self, _metadata: &crate::ga::Metrics, _individual: &IndividualT) -> bool {
+    fn on_new_best(&mut self, _metrics: &crate::ga::Metrics, _individual: &IndividualT) -> bool {
         true
     }
 
     #[inline(always)]
-    fn on_new_generation(&mut self, _metadata: &Metrics, _generation: &[IndividualT]) -> bool {
+    fn on_new_generation(&mut self, _metrics: &Metrics, _generation: &[IndividualT]) -> bool {
         self.should_log
     }
 
     #[inline(always)]
     fn on_best_fit_in_generation(
         &mut self,
-        _metadata: &crate::ga::Metrics,
+        _metrics: &crate::ga::Metrics,
         _individual: &IndividualT,
     ) -> bool {
         self.should_log
     }
 
-    fn on_iteration_start(&mut self, metadata: &Metrics) -> bool {
-        if metadata.total_dur.unwrap() >= self.threshold {
+    fn on_iteration_start(&mut self, metrics: &Metrics) -> bool {
+        if metrics.total_dur.unwrap() >= self.threshold {
             self.should_log = true;
             self.threshold += self.interval;
             true
@@ -148,7 +148,7 @@ impl<IndividualT: IndividualTrait> ProbingPolicy<IndividualT> for ElapsedTime {
     }
 
     #[inline]
-    fn on_iteration_end(&mut self, _metadata: &Metrics) -> bool {
+    fn on_iteration_end(&mut self, _metrics: &Metrics) -> bool {
         let prev = self.should_log;
         self.should_log = false;
         prev
@@ -157,7 +157,7 @@ impl<IndividualT: IndividualTrait> ProbingPolicy<IndividualT> for ElapsedTime {
     #[inline(always)]
     fn on_end(
         &mut self,
-        _metadata: &crate::ga::Metrics,
+        _metrics: &crate::ga::Metrics,
         _population: &[IndividualT],
         _best_individual: &IndividualT,
     ) -> bool {

--- a/src/ga/probe/stdout_probe.rs
+++ b/src/ga/probe/stdout_probe.rs
@@ -11,44 +11,44 @@ impl StdoutProbe {
 }
 
 impl<IndividualT: IndividualTrait> Probe<IndividualT> for StdoutProbe {
-    fn on_start(&mut self, _metadata: &Metrics) {
+    fn on_start(&mut self, _metrics: &Metrics) {
         info!("[START] time,generation,chromosome,fitness");
     }
 
-    fn on_new_best(&mut self, metadata: &Metrics, individual: &IndividualT) {
+    fn on_new_best(&mut self, metrics: &Metrics, individual: &IndividualT) {
         info!(
             "[NEW_BEST] {},{},{:?},{}",
-            metadata
+            metrics
                 .total_dur
                 .unwrap_or(std::time::Duration::from_millis(0))
                 .as_millis(),
-            metadata.generation,
+            metrics.generation,
             individual.chromosome(),
             individual.fitness()
         );
     }
 
-    fn on_new_generation(&mut self, _metadata: &Metrics, _generation: &[IndividualT]) {
+    fn on_new_generation(&mut self, _metrics: &Metrics, _generation: &[IndividualT]) {
         // TODO: Take reference to whole generation as a parameter and display it here!
         // We don't want to print anything on new generation right now
     }
 
-    fn on_best_fit_in_generation(&mut self, metadata: &Metrics, individual: &IndividualT) {
+    fn on_best_fit_in_generation(&mut self, metrics: &Metrics, individual: &IndividualT) {
         // TODO: Take reference to the best chromosome & display it here!
         info!(
             "[BEST_IN_GEN] {},{},{:?},{}",
-            metadata.total_dur.unwrap().as_millis(),
-            metadata.generation,
+            metrics.total_dur.unwrap().as_millis(),
+            metrics.generation,
             individual.chromosome(),
             individual.fitness()
         );
     }
 
-    fn on_end(&mut self, metadata: &Metrics, _population: &[IndividualT], best_individual: &IndividualT) {
+    fn on_end(&mut self, metrics: &Metrics, _population: &[IndividualT], best_individual: &IndividualT) {
         info!(
             "[END] {},{},{:?},{}",
-            metadata.total_dur.unwrap().as_millis(),
-            metadata.generation,
+            metrics.total_dur.unwrap().as_millis(),
+            metrics.generation,
             best_individual.chromosome(),
             best_individual.fitness()
         );

--- a/src/ga/probe/stdout_probe.rs
+++ b/src/ga/probe/stdout_probe.rs
@@ -1,6 +1,6 @@
 use log::info;
 
-use crate::ga::{individual::IndividualTrait, GAMetadata, Probe};
+use crate::ga::{individual::IndividualTrait, Metrics, Probe};
 
 pub struct StdoutProbe;
 
@@ -11,11 +11,11 @@ impl StdoutProbe {
 }
 
 impl<IndividualT: IndividualTrait> Probe<IndividualT> for StdoutProbe {
-    fn on_start(&mut self, _metadata: &GAMetadata) {
+    fn on_start(&mut self, _metadata: &Metrics) {
         info!("[START] time,generation,chromosome,fitness");
     }
 
-    fn on_new_best(&mut self, metadata: &GAMetadata, individual: &IndividualT) {
+    fn on_new_best(&mut self, metadata: &Metrics, individual: &IndividualT) {
         info!(
             "[NEW_BEST] {},{},{:?},{}",
             metadata
@@ -28,12 +28,12 @@ impl<IndividualT: IndividualTrait> Probe<IndividualT> for StdoutProbe {
         );
     }
 
-    fn on_new_generation(&mut self, _metadata: &GAMetadata, _generation: &[IndividualT]) {
+    fn on_new_generation(&mut self, _metadata: &Metrics, _generation: &[IndividualT]) {
         // TODO: Take reference to whole generation as a parameter and display it here!
         // We don't want to print anything on new generation right now
     }
 
-    fn on_best_fit_in_generation(&mut self, metadata: &GAMetadata, individual: &IndividualT) {
+    fn on_best_fit_in_generation(&mut self, metadata: &Metrics, individual: &IndividualT) {
         // TODO: Take reference to the best chromosome & display it here!
         info!(
             "[BEST_IN_GEN] {},{},{:?},{}",
@@ -44,7 +44,7 @@ impl<IndividualT: IndividualTrait> Probe<IndividualT> for StdoutProbe {
         );
     }
 
-    fn on_end(&mut self, metadata: &GAMetadata, _population: &[IndividualT], best_individual: &IndividualT) {
+    fn on_end(&mut self, metadata: &Metrics, _population: &[IndividualT], best_individual: &IndividualT) {
         info!(
             "[END] {},{},{:?},{}",
             metadata.total_dur.unwrap().as_millis(),

--- a/tests/crossover_tests.rs
+++ b/tests/crossover_tests.rs
@@ -2,7 +2,7 @@
 
 use ecrs::ga::individual::{IndividualTrait, RealValueIndividual};
 use ecrs::ga::operators::crossover::Ppx;
-use ecrs::ga::GAMetadata;
+use ecrs::ga::Metrics;
 use ecrs::ga::{
     operators::crossover::{CrossoverOperator, MultiPoint, SinglePoint, TwoPoint, Uniform},
     population::{PopulationGenerator, RandomPoints},
@@ -14,7 +14,7 @@ fn operator_takes_values_from_parents<T: CrossoverOperator<RealValueIndividual>>
     let parents = RandomPoints::new(30).generate(2);
     assert_eq!(parents.len(), 2, "Expected population of size 2");
 
-    let children = operator.apply(&GAMetadata::default(), &[&parents[0], &parents[1]]);
+    let children = operator.apply(&Metrics::default(), &[&parents[0], &parents[1]]);
     let child_1 = &children[0];
     let child_2 = &children[1];
     for (i, (gene_1, gene_2)) in std::iter::zip(child_1.chromosome(), child_2.chromosome()).enumerate() {
@@ -52,7 +52,7 @@ fn ppx_test() {
 
     let p1 = Individual::from((0..10).collect_vec());
     let p2 = Individual::from((0..10).rev().collect_vec());
-    let children = op.apply(&GAMetadata::default(), &[&p1, &p2]);
+    let children = op.apply(&Metrics::default(), &[&p1, &p2]);
     let c1 = &children[0];
     let c2 = &children[1];
 

--- a/tests/replacement_tests.rs
+++ b/tests/replacement_tests.rs
@@ -3,7 +3,7 @@
 use ecrs::ga::{
     operators::replacement::{BothParents, Noop, ReplacementOperator},
     population::{PopulationGenerator, RandomPoints},
-    GAMetadata, Individual,
+    Metrics, Individual,
 };
 
 #[test]
@@ -18,7 +18,7 @@ fn noop_does_nothing() {
 
     let mut noop = Noop::new();
 
-    let result = noop.apply(&GAMetadata::default(), population, children);
+    let result = noop.apply(&Metrics::default(), population, children);
 
     assert_eq!(result, population_clone);
 }
@@ -36,7 +36,7 @@ fn both_parents_returns_children() {
 
     let mut both_parents = BothParents::new();
 
-    let result = both_parents.apply(&GAMetadata::default(), population, children);
+    let result = both_parents.apply(&Metrics::default(), population, children);
 
     assert_eq!(result, children_clone);
 }

--- a/tests/replacement_tests.rs
+++ b/tests/replacement_tests.rs
@@ -3,7 +3,7 @@
 use ecrs::ga::{
     operators::replacement::{BothParents, Noop, ReplacementOperator},
     population::{PopulationGenerator, RandomPoints},
-    Metrics, Individual,
+    Individual, Metrics,
 };
 
 #[test]

--- a/tests/selection_tests.rs
+++ b/tests/selection_tests.rs
@@ -22,11 +22,11 @@ fn random_selection_returns_demanded_size() {
     );
 
     // FIXME: We must add mocking!
-    let metadata = Metrics::default();
+    let metrics = Metrics::default();
 
     let expected_selection_size = expected_population_size / 2;
 
-    let selected = Random::new().apply(&metadata, &population, expected_selection_size);
+    let selected = Random::new().apply(&metrics, &population, expected_selection_size);
 
     assert_eq!(
         expected_selection_size,
@@ -47,11 +47,11 @@ fn roulette_whell_returns_demanded_size() {
     );
 
     // FIXME: We must add mocking!
-    let metadata = Metrics::default();
+    let metrics = Metrics::default();
 
     let expected_selection_size = expected_population_size / 2;
 
-    let selected = RouletteWheel::new().apply(&metadata, &population, expected_selection_size);
+    let selected = RouletteWheel::new().apply(&metrics, &population, expected_selection_size);
 
     assert_eq!(
         expected_selection_size,
@@ -72,11 +72,11 @@ fn rank_returns_demanded_size() {
     );
 
     // FIXME: We must add mocking!
-    let metadata = Metrics::default();
+    let metrics = Metrics::default();
 
     let expected_selection_size = expected_population_size / 2;
 
-    let selected = Rank::new().apply(&metadata, &population, expected_selection_size);
+    let selected = Rank::new().apply(&metrics, &population, expected_selection_size);
 
     assert_eq!(
         expected_selection_size,
@@ -97,11 +97,11 @@ fn rankr_returns_demanded_size() {
     );
 
     // FIXME: We must add mocking!
-    let metadata = Metrics::default();
+    let metrics = Metrics::default();
 
     let expected_selection_size = expected_population_size / 2;
 
-    let selected = RankR::new(0.5).apply(&metadata, &population, expected_selection_size);
+    let selected = RankR::new(0.5).apply(&metrics, &population, expected_selection_size);
 
     assert_eq!(
         expected_selection_size,
@@ -122,11 +122,11 @@ fn tournament_returns_demanded_size() {
     );
 
     // FIXME: We must add mocking!
-    let metadata = Metrics::default();
+    let metrics = Metrics::default();
 
     let expected_selection_size = expected_population_size / 2;
 
-    let selected = Tournament::new(0.2).apply(&metadata, &population, expected_selection_size);
+    let selected = Tournament::new(0.2).apply(&metrics, &population, expected_selection_size);
 
     assert_eq!(
         expected_selection_size,
@@ -152,11 +152,11 @@ fn sus_returns_demanded_size_when_fitness_positive() {
     );
 
     // FIXME: We must add mocking!
-    let metadata = Metrics::default();
+    let metrics = Metrics::default();
 
     let expected_selection_size = expected_population_size / 2;
 
-    let selected = StochasticUniversalSampling::new().apply(&metadata, &population, expected_selection_size);
+    let selected = StochasticUniversalSampling::new().apply(&metrics, &population, expected_selection_size);
 
     assert_eq!(
         expected_selection_size,
@@ -186,9 +186,9 @@ fn boltzmann_returns_demanded_size() {
     );
 
     // FIXME: We must add mocking!
-    let metadata = Metrics::new(Some(std::time::Instant::now()), None, 40);
+    let metrics = Metrics::new(Some(std::time::Instant::now()), None, 40);
 
-    let selected = Boltzmann::new(0.2, 6.0, 300, true).apply(&metadata, &population, expected_selection_size);
+    let selected = Boltzmann::new(0.2, 6.0, 300, true).apply(&metrics, &population, expected_selection_size);
 
     assert_eq!(
         expected_selection_size,

--- a/tests/selection_tests.rs
+++ b/tests/selection_tests.rs
@@ -7,7 +7,7 @@ use ecrs::ga::{
         Tournament,
     },
     population::{BitStrings, PopulationGenerator, RandomPoints},
-    GAMetadata,
+    Metrics,
 };
 
 #[test]
@@ -22,7 +22,7 @@ fn random_selection_returns_demanded_size() {
     );
 
     // FIXME: We must add mocking!
-    let metadata = GAMetadata::default();
+    let metadata = Metrics::default();
 
     let expected_selection_size = expected_population_size / 2;
 
@@ -47,7 +47,7 @@ fn roulette_whell_returns_demanded_size() {
     );
 
     // FIXME: We must add mocking!
-    let metadata = GAMetadata::default();
+    let metadata = Metrics::default();
 
     let expected_selection_size = expected_population_size / 2;
 
@@ -72,7 +72,7 @@ fn rank_returns_demanded_size() {
     );
 
     // FIXME: We must add mocking!
-    let metadata = GAMetadata::default();
+    let metadata = Metrics::default();
 
     let expected_selection_size = expected_population_size / 2;
 
@@ -97,7 +97,7 @@ fn rankr_returns_demanded_size() {
     );
 
     // FIXME: We must add mocking!
-    let metadata = GAMetadata::default();
+    let metadata = Metrics::default();
 
     let expected_selection_size = expected_population_size / 2;
 
@@ -122,7 +122,7 @@ fn tournament_returns_demanded_size() {
     );
 
     // FIXME: We must add mocking!
-    let metadata = GAMetadata::default();
+    let metadata = Metrics::default();
 
     let expected_selection_size = expected_population_size / 2;
 
@@ -152,7 +152,7 @@ fn sus_returns_demanded_size_when_fitness_positive() {
     );
 
     // FIXME: We must add mocking!
-    let metadata = GAMetadata::default();
+    let metadata = Metrics::default();
 
     let expected_selection_size = expected_population_size / 2;
 
@@ -186,7 +186,7 @@ fn boltzmann_returns_demanded_size() {
     );
 
     // FIXME: We must add mocking!
-    let metadata = GAMetadata::new(Some(std::time::Instant::now()), None, 40);
+    let metadata = Metrics::new(Some(std::time::Instant::now()), None, 40);
 
     let selected = Boltzmann::new(0.2, 6.0, 300, true).apply(&metadata, &population, expected_selection_size);
 
@@ -205,7 +205,7 @@ fn random_returns_whole_population_in_order() {
     let population: Vec<RealValueIndividual> = RandomPoints::new(dim).generate(population_size);
     let mut operator = Random::with_rng(rand::rngs::mock::StepRng::new(0, 1));
 
-    let selected = operator.apply(&GAMetadata::default(), &population, population_size);
+    let selected = operator.apply(&Metrics::default(), &population, population_size);
 
     for (expected, actual) in std::iter::zip(&population, selected) {
         assert_eq!(expected, actual);


### PR DESCRIPTION
<!-- If applicable - remember to add the PR to the EA Rust project (ONLY IF THERE IS NO LINKED ISSUE) -->

## Description

- Add assertion on constant population size
- Fix comments on mutation operator
- Rename `GAMetadata` -> `Metrics`
- fmt
- Drop assertion on even population size in GeneticSolver::new
- Rename all occurences of metadata


## Linked issues <!-- Please use "Resolves #<issue_no> syntax in case this PR should be linked to an issue -->

Closes #480
Closes #479

## Important implementation details <!-- if any, optional section -->

