### PR TITLE
feat!: allow for using adaptive values with operators by introducing ValueProvider trait

### DIFF
--- a/coco/src/main.rs
+++ b/coco/src/main.rs
@@ -103,7 +103,7 @@ fn ecrs_ga_search(problem: &mut Problem, _max_budget: usize, _random_generator: 
         RealValueIndividual,
         Reversing,
         Uniform,
-        Tournament,
+        Tournament<usize>,
         WeakParent,
         RandomPoints,
         adapter::CocoFitness,
@@ -118,7 +118,7 @@ fn ecrs_ga_search(problem: &mut Problem, _max_budget: usize, _random_generator: 
         dimension,
         constraints,
     ))
-    .set_selection_operator(selection::Tournament::new(0.2))
+    .set_selection_operator(selection::Tournament::new(0.2, population_size))
     .set_crossover_operator(crossover::Uniform::new())
     .set_mutation_operator(mutation::Reversing::new(0.05))
     .set_replacement_operator(replacement::WeakParent::new())

--- a/examples/ga.rs
+++ b/examples/ga.rs
@@ -36,7 +36,7 @@ fn main() {
         3,
         vec![-5.12..5.12, -5.12..5.12, -5.12..5.12],
     ))
-    .set_selection_operator(ga::operators::selection::Boltzmann::new(0.05, 80.0, 500, false))
+    .set_selection_operator(ga::operators::selection::Boltzmann::new(100, 0.05, 80.0, 500, false))
     .set_probe(
         ga::probe::AggregatedProbe::new()
             .add_probe(ga::probe::PolicyDrivenProbe::new(

--- a/examples/ga.rs
+++ b/examples/ga.rs
@@ -36,7 +36,9 @@ fn main() {
         3,
         vec![-5.12..5.12, -5.12..5.12, -5.12..5.12],
     ))
-    .set_selection_operator(ga::operators::selection::Boltzmann::new(100, 0.05, 80.0, 500, false))
+    .set_selection_operator(ga::operators::selection::Boltzmann::new(
+        100, 0.05, 80.0, 500, false,
+    ))
     .set_probe(
         ga::probe::AggregatedProbe::new()
             .add_probe(ga::probe::PolicyDrivenProbe::new(

--- a/examples/ga.rs
+++ b/examples/ga.rs
@@ -20,7 +20,7 @@ fn main() {
         RealValueIndividual,
         Identity,
         SinglePoint,
-        Boltzmann,
+        Boltzmann<usize>,
         WeakParent,
         RandomPoints,
         FnBasedFitness<RealValueIndividual>,

--- a/examples/jssp/main.rs
+++ b/examples/jssp/main.rs
@@ -113,7 +113,7 @@ fn run_jssp_solver(instance: JsspInstance, config: Config) {
     // }
 
     ga::Builder::new()
-        .set_selection_operator(selection::Rank::new())
+        .set_selection_operator(selection::Rank::new(pop_size))
         .set_crossover_operator(JsspCrossover::new())
         .set_mutation_operator(mutation::Identity::new())
         .set_population_generator(JsspPopProvider::new(instance.clone()))

--- a/examples/jssp/problem/selection.rs
+++ b/examples/jssp/problem/selection.rs
@@ -15,7 +15,6 @@ impl SelectionOperator<JsspIndividual> for EmptySelection {
         &mut self,
         _metrics: &ecrs::ga::Metrics,
         _population: &'a [JsspIndividual],
-        _count: usize,
     ) -> Vec<&'a JsspIndividual> {
         Vec::new()
     }

--- a/src/ga.rs
+++ b/src/ga.rs
@@ -121,8 +121,8 @@ pub mod individual;
 pub mod operators;
 pub mod population;
 pub mod probe;
-pub mod value_provider;
 pub(crate) mod timer;
+pub mod value_provider;
 
 use crate::ga::operators::fitness::Fitness;
 pub use builder::*;
@@ -309,9 +309,7 @@ where
             // 4. Create mating pool by applying selection operator.
             self.timer.start();
             let mating_pool: Vec<&IndividualT> =
-                self.config
-                    .selection_operator
-                    .apply(&self.metrics, &population);
+                self.config.selection_operator.apply(&self.metrics, &population);
             self.metrics.selection_dur = Some(self.timer.elapsed());
 
             // 5. From mating pool create new generation (apply crossover & mutation).

--- a/src/ga.rs
+++ b/src/ga.rs
@@ -311,7 +311,7 @@ where
             let mating_pool: Vec<&IndividualT> =
                 self.config
                     .selection_operator
-                    .apply(&self.metrics, &population, population.len());
+                    .apply(&self.metrics, &population);
             self.metrics.selection_dur = Some(self.timer.elapsed());
 
             // 5. From mating pool create new generation (apply crossover & mutation).

--- a/src/ga.rs
+++ b/src/ga.rs
@@ -121,6 +121,7 @@ pub mod individual;
 pub mod operators;
 pub mod population;
 pub mod probe;
+pub mod value_provider;
 pub(crate) mod timer;
 
 use crate::ga::operators::fitness::Fitness;

--- a/src/ga.rs
+++ b/src/ga.rs
@@ -65,7 +65,7 @@
 //!     ga::individual::RealValueIndividual,
 //!     mutation::Identity,
 //!     crossover::SinglePoint,
-//!     selection::Boltzmann,
+//!     selection::Boltzmann<usize>,
 //!     replacement::WeakParent,
 //!     population::RandomPoints,
 //!     fitness::FnBasedFitness<ga::individual::RealValueIndividual>,
@@ -81,7 +81,7 @@
 //!     3,
 //!     vec![-5.12..5.12, -5.12..5.12, -5.12..5.12],
 //!   ))
-//!   .set_selection_operator(ga::operators::selection::Boltzmann::new(0.05, 80.0, 500, false))
+//!   .set_selection_operator(ga::operators::selection::Boltzmann::new(100, 0.05, 80.0, 500, false))
 //!   .set_probe(
 //!     ga::probe::AggregatedProbe::new()
 //!       .add_probe(ga::probe::PolicyDrivenProbe::new(

--- a/src/ga/builder/bitstring.rs
+++ b/src/ga/builder/bitstring.rs
@@ -25,7 +25,7 @@ pub struct BitStringBuilder<F: Fitness<BitStringIndividual>> {
         Individual<Bsc>,
         FlipBit<rand::rngs::ThreadRng>,
         SinglePoint<rand::rngs::ThreadRng>,
-        Tournament<rand::rngs::ThreadRng>,
+        Tournament<usize, rand::rngs::ThreadRng>,
         BothParents,
         BitStrings<rand::rngs::ThreadRng>,
         F,
@@ -126,7 +126,7 @@ impl<F: Fitness<BitStringIndividual>> BitStringBuilder<F> {
         Individual<Bsc>,
         FlipBit<rand::rngs::ThreadRng>,
         SinglePoint<rand::rngs::ThreadRng>,
-        Tournament<rand::rngs::ThreadRng>,
+        Tournament<usize, rand::rngs::ThreadRng>,
         BothParents,
         BitStrings<rand::rngs::ThreadRng>,
         F,
@@ -150,7 +150,7 @@ impl<F: Fitness<BitStringIndividual>> BitStringBuilder<F> {
             .get_or_insert_with(|| FlipBit::new(0.05));
         self.config
             .selection_operator
-            .get_or_insert_with(|| Tournament::new(0.2));
+            .get_or_insert_with(|| Tournament::new(0.2, self.config.params.population_size.unwrap()));
         self.config
             .replacement_operator
             .get_or_insert_with(BothParents::new);

--- a/src/ga/builder/realvalued.rs
+++ b/src/ga/builder/realvalued.rs
@@ -24,7 +24,7 @@ pub struct RealValuedBuilder<F: Fitness<RealValueIndividual>> {
         Individual<Rvc>,
         Interchange<rand::rngs::ThreadRng>,
         SinglePoint<rand::rngs::ThreadRng>,
-        Tournament<rand::rngs::ThreadRng>,
+        Tournament<usize, rand::rngs::ThreadRng>,
         BothParents,
         RandomPoints<rand::rngs::ThreadRng>,
         F,
@@ -125,7 +125,7 @@ impl<F: Fitness<RealValueIndividual>> RealValuedBuilder<F> {
         Individual<Rvc>,
         Interchange<rand::rngs::ThreadRng>,
         SinglePoint<rand::rngs::ThreadRng>,
-        Tournament<rand::rngs::ThreadRng>,
+        Tournament<usize, rand::rngs::ThreadRng>,
         BothParents,
         RandomPoints<rand::rngs::ThreadRng>,
         F,
@@ -149,7 +149,7 @@ impl<F: Fitness<RealValueIndividual>> RealValuedBuilder<F> {
             .get_or_insert_with(|| Interchange::new(0.05));
         self.config
             .selection_operator
-            .get_or_insert_with(|| Tournament::new(0.2));
+            .get_or_insert_with(|| Tournament::new(0.2, self.config.params.population_size.unwrap()));
         self.config
             .replacement_operator
             .get_or_insert_with(BothParents::new);

--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -28,9 +28,5 @@ pub trait SelectionOperator<IndividualT: IndividualTrait> {
     ///
     /// * `metrics` - [crate::ga::Metrics] information on current stage of the algorithm (iteration, elapsed time, etc.)
     /// * `population` - individuals to choose mating pool from
-    fn apply<'a>(
-        &mut self,
-        metrics: &Metrics,
-        population: &'a [IndividualT],
-    ) -> Vec<&'a IndividualT>;
+    fn apply<'a>(&mut self, metrics: &Metrics, population: &'a [IndividualT]) -> Vec<&'a IndividualT>;
 }

--- a/src/ga/operators/selection.rs
+++ b/src/ga/operators/selection.rs
@@ -28,11 +28,9 @@ pub trait SelectionOperator<IndividualT: IndividualTrait> {
     ///
     /// * `metrics` - [crate::ga::Metrics] information on current stage of the algorithm (iteration, elapsed time, etc.)
     /// * `population` - individuals to choose mating pool from
-    /// * `count` - target number of individuals in mating pool
     fn apply<'a>(
         &mut self,
         metrics: &Metrics,
         population: &'a [IndividualT],
-        count: usize,
     ) -> Vec<&'a IndividualT>;
 }

--- a/src/ga/operators/selection/impls.rs
+++ b/src/ga/operators/selection/impls.rs
@@ -25,7 +25,12 @@ pub struct RouletteWheel<SizeValue: ValueProvider<usize>, R: Rng = ThreadRng> {
 }
 
 impl<SizeValue: ValueProvider<usize>> RouletteWheel<SizeValue, ThreadRng> {
-    /// Returns new instance of [RouletteWheel] selection operator with default RNG
+    /// Returns new instance of [RouletteWheel] selection operator with default RNG.
+    ///
+    /// ## Arguments
+    ///
+    /// * `selection_size` - value provider deciding how many individuals will selection operator
+    /// produce
     pub fn new(selection_size: SizeValue) -> Self {
         RouletteWheel::with_rng(selection_size, rand::thread_rng())
     }
@@ -33,6 +38,11 @@ impl<SizeValue: ValueProvider<usize>> RouletteWheel<SizeValue, ThreadRng> {
 
 impl<SizeValue: ValueProvider<usize>, R: Rng> RouletteWheel<SizeValue, R> {
     /// Returns new instance of [RouletteWheel] selection operator with custom RNG
+    ///
+    /// ## Arguments
+    ///
+    /// * `selection_size` - value provider deciding how many individuals will selection operator
+    /// produce
     pub fn with_rng(selection_size: SizeValue, rng: R) -> Self {
         RouletteWheel { selection_size, rng }
     }
@@ -99,6 +109,11 @@ pub struct Random<SizeValue: ValueProvider<usize>, R: Rng = ThreadRng> {
 
 impl<SizeValue: ValueProvider<usize>> Random<SizeValue, ThreadRng> {
     /// Returns new instance of [Random] selection operator with default RNG
+    ///
+    /// ## Arguments
+    ///
+    /// * `selection_size` - value provider deciding how many individuals will selection operator
+    /// produce
     pub fn new(selection_size: SizeValue) -> Self {
         Random::with_rng(selection_size, rand::thread_rng())
     }
@@ -106,6 +121,11 @@ impl<SizeValue: ValueProvider<usize>> Random<SizeValue, ThreadRng> {
 
 impl<SizeValue: ValueProvider<usize>, R: Rng> Random<SizeValue, R> {
     /// Returns new instance of [Random] selection operator with custom RNG
+    ///
+    /// ## Arguments
+    ///
+    /// * `selection_size` - value provider deciding how many individuals will selection operator
+    /// produce
     pub fn with_rng(selection_size: SizeValue, rng: R) -> Self {
         Random { selection_size, rng }
     }
@@ -156,6 +176,11 @@ pub struct Rank<SizeValue: ValueProvider<usize>, R: Rng = ThreadRng> {
 
 impl<SizeValue: ValueProvider<usize>> Rank<SizeValue, ThreadRng> {
     /// Returns new instance of [Rank] selection operator with default RNG
+    ///
+    /// ## Arguments
+    ///
+    /// * `selection_size` - value provider deciding how many individuals will selection operator
+    /// produce
     pub fn new(selection_size: SizeValue) -> Self {
         Rank::with_rng(selection_size, rand::thread_rng())
     }
@@ -163,6 +188,11 @@ impl<SizeValue: ValueProvider<usize>> Rank<SizeValue, ThreadRng> {
 
 impl<SizeValue: ValueProvider<usize>, R: Rng> Rank<SizeValue, R> {
     /// Returns new instance of [Rank] selection operator with custom RNG
+    ///
+    /// ## Arguments
+    ///
+    /// * `selection_size` - value provider deciding how many individuals will selection operator
+    /// produce
     pub fn with_rng(selection_size: SizeValue, rng: R) -> Self {
         Rank { selection_size, rng }
     }
@@ -229,6 +259,8 @@ impl<SizeValue: ValueProvider<usize>> RankR<SizeValue, ThreadRng> {
     /// ### Arguments
     ///
     /// * `r` - threshold in range [0, 1]; see [RankR] description for explaination
+    /// * `selection_size` - value provider deciding how many individuals will selection operator
+    /// produce
     pub fn new(r: f64, selection_size: SizeValue) -> Self {
         RankR::with_rng(r, selection_size, rand::thread_rng())
     }
@@ -240,6 +272,8 @@ impl<SizeValue: ValueProvider<usize>, R: Rng> RankR<SizeValue, R> {
     /// ### Arguments
     ///
     /// * `r` - threshold in range [0, 1]; see [RankR] description for details
+    /// * `selection_size` - value provider deciding how many individuals will selection operator
+    /// produce
     /// * `rng` - custom random number generator
     pub fn with_rng(r: f64, selection_size: SizeValue, rng: R) -> Self {
         assert!((0.0..=1.0).contains(&r));
@@ -313,6 +347,8 @@ impl<SizeValue: ValueProvider<usize>> Tournament<SizeValue, ThreadRng> {
     /// ### Arguments
     ///
     /// * `size_factor` - part of population to take part in tournament for choosing single individual; must be in range [0, 1]
+    /// * `selection_size` - value provider deciding how many individuals will selection operator
+    /// produce
     pub fn new(size_factor: f64, selection_size: SizeValue) -> Self {
         Self::with_rng(size_factor, selection_size, rand::thread_rng())
     }
@@ -324,6 +360,8 @@ impl<SizeValue: ValueProvider<usize>, R: Rng> Tournament<SizeValue, R> {
     /// ### Arguments
     ///
     /// * `size_factor` - part of population to take part in tournament for choosing single individual; must be in range [0, 1]
+    /// * `selection_size` - value provider deciding how many individuals will selection operator
+    /// produce
     pub fn with_rng(size_factor: f64, selection_size: SizeValue, rng: R) -> Self {
         assert!((0.0..=1.0).contains(&size_factor));
         Tournament { size_factor, selection_size, rng }
@@ -401,6 +439,11 @@ pub struct StochasticUniversalSampling<SizeValue: ValueProvider<usize>, R: Rng =
 
 impl<SizeValue: ValueProvider<usize>> StochasticUniversalSampling<SizeValue, ThreadRng> {
     /// Returns new instance of [StochasticUniversalSampling] selection operator with default RNG
+    ///
+    /// ## Arguments
+    ///
+    /// * `selection_size` - value provider deciding how many individuals will selection operator
+    /// produce
     pub fn new(selection_size: SizeValue) -> Self {
         Self::with_rng(selection_size, rand::thread_rng())
     }
@@ -408,6 +451,11 @@ impl<SizeValue: ValueProvider<usize>> StochasticUniversalSampling<SizeValue, Thr
 
 impl<SizeValue: ValueProvider<usize>, R: Rng> StochasticUniversalSampling<SizeValue, R> {
     /// Returns new instance of [StochasticUniversalSampling] selection operator with custom RNG
+    ///
+    /// ## Arguments
+    ///
+    /// * `selection_size` - value provider deciding how many individuals will selection operator
+    /// produce
     pub fn with_rng(selection_size: SizeValue, rng: R) -> Self {
         Self { selection_size, rng }
     }
@@ -492,6 +540,8 @@ impl<SizeValue: ValueProvider<usize>> Boltzmann<SizeValue, ThreadRng> {
     ///
     /// ### Arguments
     ///
+    /// * `selection_size` - value provider deciding how many individuals will selection operator
+    /// produce
     /// * `alpha` - prameter that controlls temperature scaling; must be in [0, 1] range
     /// * `temp_0` - initial temperature for the operator
     /// * `max_gen_count` - maximum number of generations GA can run; this param will be removed in future version of the library
@@ -506,6 +556,8 @@ impl<SizeValue: ValueProvider<usize>, R: Rng> Boltzmann<SizeValue, R> {
     ///
     /// ### Arguments
     ///
+    /// * `selection_size` - value provider deciding how many individuals will selection operator
+    /// produce
     /// * `alpha` - prameter that controlls temperature scaling; must be in [0, 1] range
     /// * `temp_0` - initial temperature for the operator
     /// * `max_gen_count` - maximum number of generations GA can run; this param will be removed in future version of the library

--- a/src/ga/operators/selection/impls.rs
+++ b/src/ga/operators/selection/impls.rs
@@ -628,36 +628,36 @@ mod test {
     #[test]
     #[should_panic]
     fn boltzman_panics_on_too_big_alpha() {
-        let _operator = Boltzmann::new(5.0, 10.0, 300, false);
+        let _operator = Boltzmann::new(100, 5.0, 10.0, 300, false);
     }
 
     #[test]
     #[should_panic]
     fn boltzman_panics_on_too_small_alpha() {
-        let _operator = Boltzmann::new(-0.1, 10.0, 300, false);
+        let _operator = Boltzmann::new(100, -0.1, 10.0, 300, false);
     }
 
     #[test]
     #[should_panic]
     fn boltzman_panics_on_too_low_temp() {
-        let _operator = Boltzmann::new(0.5, 4.0, 300, false);
+        let _operator = Boltzmann::new(100, 0.5, 4.0, 300, false);
     }
 
     #[test]
     #[should_panic]
     fn boltzman_panics_on_too_high_temp() {
-        let _operator = Boltzmann::new(0.5, 400.0, 300, false);
+        let _operator = Boltzmann::new(100, 0.5, 400.0, 300, false);
     }
 
     #[test]
     #[should_panic]
     fn tournament_panics_on_wrong_size_factor() {
-        let _operator = Tournament::new(2.0);
+        let _operator = Tournament::new(2.0, 100);
     }
 
     #[test]
     #[should_panic]
     fn rankr_panics_on_wrong_r() {
-        let _operator = RankR::new(1.1);
+        let _operator = RankR::new(1.1, 100);
     }
 }

--- a/src/ga/operators/selection/impls.rs
+++ b/src/ga/operators/selection/impls.rs
@@ -144,11 +144,7 @@ impl<IndividualT: IndividualTrait, SizeValue: ValueProvider<usize>, R: Rng> Sele
     ///
     /// * `metrics` - [crate::ga::Metrics] information on current stage of the algorithm (iteration, elapsed time, etc.)
     /// * `population` - individuals to choose mating pool from
-    fn apply<'a>(
-        &mut self,
-        metrics: &Metrics,
-        population: &'a [IndividualT],
-    ) -> Vec<&'a IndividualT> {
+    fn apply<'a>(&mut self, metrics: &Metrics, population: &'a [IndividualT]) -> Vec<&'a IndividualT> {
         let count = self.selection_size.get(metrics);
         // We must use index API, as we want to return vector of references, not vector of actual items
         let indices = rand::seq::index::sample(&mut self.rng, population.len(), count);
@@ -198,7 +194,8 @@ impl<SizeValue: ValueProvider<usize>, R: Rng> Rank<SizeValue, R> {
     }
 }
 
-impl<IndividualT: IndividualTrait, SizeValue: ValueProvider<usize>, R: Rng> SelectionOperator<IndividualT> for Rank<SizeValue, R>
+impl<IndividualT: IndividualTrait, SizeValue: ValueProvider<usize>, R: Rng> SelectionOperator<IndividualT>
+    for Rank<SizeValue, R>
 where
     IndividualT::FitnessValueT: PartialOrd,
 {
@@ -213,11 +210,7 @@ where
     ///
     /// * `metrics` - [crate::ga::Metrics] information on current stage of the algorithm (iteration, elapsed time, etc.)
     /// * `population` - individuals to choose mating pool from
-    fn apply<'a>(
-        &mut self,
-        metrics: &Metrics,
-        population: &'a [IndividualT],
-    ) -> Vec<&'a IndividualT> {
+    fn apply<'a>(&mut self, metrics: &Metrics, population: &'a [IndividualT]) -> Vec<&'a IndividualT> {
         let count = self.selection_size.get(metrics);
         let mut selected: Vec<&IndividualT> = Vec::with_capacity(count);
 
@@ -277,11 +270,17 @@ impl<SizeValue: ValueProvider<usize>, R: Rng> RankR<SizeValue, R> {
     /// * `rng` - custom random number generator
     pub fn with_rng(r: f64, selection_size: SizeValue, rng: R) -> Self {
         assert!((0.0..=1.0).contains(&r));
-        RankR { r, selection_size, rng }
+        RankR {
+            r,
+            selection_size,
+            rng,
+        }
     }
 }
 
-impl<IndividualT: IndividualTrait, SizeValue: ValueProvider<usize>, R: Rng> SelectionOperator<IndividualT> for RankR<SizeValue, R> {
+impl<IndividualT: IndividualTrait, SizeValue: ValueProvider<usize>, R: Rng> SelectionOperator<IndividualT>
+    for RankR<SizeValue, R>
+{
     /// Returns a vector of references to individuals selected to mating pool.
     ///
     /// Individuals are selected in following process:
@@ -297,11 +296,7 @@ impl<IndividualT: IndividualTrait, SizeValue: ValueProvider<usize>, R: Rng> Sele
     ///
     /// * `metrics` - [crate::ga::Metrics] information on current stage of the algorithm (iteration, elapsed time, etc.)
     /// * `population` - individuals to choose mating pool from
-    fn apply<'a>(
-        &mut self,
-        metrics: &Metrics,
-        population: &'a [IndividualT],
-    ) -> Vec<&'a IndividualT> {
+    fn apply<'a>(&mut self, metrics: &Metrics, population: &'a [IndividualT]) -> Vec<&'a IndividualT> {
         let count = self.selection_size.get(metrics);
         let mut selected: Vec<&IndividualT> = Vec::with_capacity(count);
         let population_len = population.len();
@@ -364,11 +359,17 @@ impl<SizeValue: ValueProvider<usize>, R: Rng> Tournament<SizeValue, R> {
     /// produce
     pub fn with_rng(size_factor: f64, selection_size: SizeValue, rng: R) -> Self {
         assert!((0.0..=1.0).contains(&size_factor));
-        Tournament { size_factor, selection_size, rng }
+        Tournament {
+            size_factor,
+            selection_size,
+            rng,
+        }
     }
 }
 
-impl<IndividualT: IndividualTrait, SizeValue: ValueProvider<usize>, R: Rng> SelectionOperator<IndividualT> for Tournament<SizeValue, R> {
+impl<IndividualT: IndividualTrait, SizeValue: ValueProvider<usize>, R: Rng> SelectionOperator<IndividualT>
+    for Tournament<SizeValue, R>
+{
     /// Returns a vector of references to individuals selected to mating pool
     ///
     /// Individuals are selected by conducting given number of tournaments with single winner:
@@ -384,11 +385,7 @@ impl<IndividualT: IndividualTrait, SizeValue: ValueProvider<usize>, R: Rng> Sele
     /// * `metrics` - [crate::ga::Metrics] information on current stage of the algorithm (iteration, elapsed time, etc.)
     /// * `population` - individuals to choose mating pool from
     /// * `count` - target number of individuals in mating pool
-    fn apply<'a>(
-        &mut self,
-        metrics: &Metrics,
-        population: &'a [IndividualT],
-    ) -> Vec<&'a IndividualT> {
+    fn apply<'a>(&mut self, metrics: &Metrics, population: &'a [IndividualT]) -> Vec<&'a IndividualT> {
         let count = self.selection_size.get(metrics);
         let tournament_size = (population.len() as f64 * self.size_factor) as usize;
         let tournament_size = tournament_size.max(1);
@@ -463,8 +460,8 @@ impl<SizeValue: ValueProvider<usize>, R: Rng> StochasticUniversalSampling<SizeVa
 
 // FIXME: Panics then total_fitness == 0
 // Should this be expected or do we want to handle this?
-impl<IndividualT: IndividualTrait<FitnessValueT = f64>, SizeValue: ValueProvider<usize>, R: Rng> SelectionOperator<IndividualT>
-    for StochasticUniversalSampling<SizeValue, R>
+impl<IndividualT: IndividualTrait<FitnessValueT = f64>, SizeValue: ValueProvider<usize>, R: Rng>
+    SelectionOperator<IndividualT> for StochasticUniversalSampling<SizeValue, R>
 {
     /// Returns a vector of references to individuals selected to mating pool
     ///
@@ -490,11 +487,7 @@ impl<IndividualT: IndividualTrait<FitnessValueT = f64>, SizeValue: ValueProvider
     ///
     /// * `metrics` - [crate::ga::Metrics] information on current stage of the algorithm (iteration, elapsed time, etc.)
     /// * `population` - individuals to choose mating pool from
-    fn apply<'a>(
-        &mut self,
-        metrics: &Metrics,
-        population: &'a [IndividualT],
-    ) -> Vec<&'a IndividualT> {
+    fn apply<'a>(&mut self, metrics: &Metrics, population: &'a [IndividualT]) -> Vec<&'a IndividualT> {
         let count = self.selection_size.get(metrics);
         let total_fitness: f64 = population.iter().map(|indiv| indiv.fitness()).sum();
 
@@ -546,8 +539,21 @@ impl<SizeValue: ValueProvider<usize>> Boltzmann<SizeValue, ThreadRng> {
     /// * `temp_0` - initial temperature for the operator
     /// * `max_gen_count` - maximum number of generations GA can run; this param will be removed in future version of the library
     /// * `elitism` - set to true to ensure that best individuals end in mating pool no matter operator results; **not supported yet**
-    pub fn new(selection_size: SizeValue, alpha: f64, temp_0: f64, max_gen_count: usize, elitism: bool) -> Self {
-        Self::with_rng(selection_size, alpha, temp_0, max_gen_count, elitism, rand::thread_rng())
+    pub fn new(
+        selection_size: SizeValue,
+        alpha: f64,
+        temp_0: f64,
+        max_gen_count: usize,
+        elitism: bool,
+    ) -> Self {
+        Self::with_rng(
+            selection_size,
+            alpha,
+            temp_0,
+            max_gen_count,
+            elitism,
+            rand::thread_rng(),
+        )
     }
 }
 
@@ -563,7 +569,14 @@ impl<SizeValue: ValueProvider<usize>, R: Rng> Boltzmann<SizeValue, R> {
     /// * `max_gen_count` - maximum number of generations GA can run; this param will be removed in future version of the library
     /// * `elitism` - set to true to ensure that best individuals end in mating pool no matter operator results; **not supported yet**
     /// * `rng` - custom random number generator
-    pub fn with_rng(selection_size: SizeValue, alpha: f64, temp_0: f64, max_gen_count: usize, elitism: bool, rng: R) -> Self {
+    pub fn with_rng(
+        selection_size: SizeValue,
+        alpha: f64,
+        temp_0: f64,
+        max_gen_count: usize,
+        elitism: bool,
+        rng: R,
+    ) -> Self {
         assert!(
             (0.0..=1.0).contains(&alpha),
             "Alpha parameter must be a value from [0, 1] interval"
@@ -591,11 +604,7 @@ where
     SizeValue: ValueProvider<usize>,
     R: Rng,
 {
-    fn apply<'a>(
-        &mut self,
-        metrics: &Metrics,
-        population: &'a [IndividualT],
-    ) -> Vec<&'a IndividualT> {
+    fn apply<'a>(&mut self, metrics: &Metrics, population: &'a [IndividualT]) -> Vec<&'a IndividualT> {
         let count = self.selection_size.get(metrics);
         let mut selected: Vec<&IndividualT> = Vec::with_capacity(count);
         let mut weights: Vec<f64> = Vec::with_capacity(count);

--- a/src/ga/value_provider.rs
+++ b/src/ga/value_provider.rs
@@ -1,7 +1,5 @@
 pub mod flat;
 
-
-
 use super::Metrics;
 
 // The `sized` bound here was not thinked through. It is possible

--- a/src/ga/value_provider.rs
+++ b/src/ga/value_provider.rs
@@ -9,4 +9,3 @@ use super::Metrics;
 pub trait ValueProvider<T: Sized + Clone> {
     fn get(&mut self, metrics: &Metrics) -> T;
 }
-

--- a/src/ga/value_provider.rs
+++ b/src/ga/value_provider.rs
@@ -1,0 +1,12 @@
+pub mod flat;
+
+use num_traits::{Float, Num};
+
+use super::Metrics;
+
+// The `sized` bound here was not thinked through. It is possible
+// to resign from it
+pub trait ValueProvider<T: Sized + Clone> {
+    fn get(&mut self, metrics: &Metrics) -> T;
+}
+

--- a/src/ga/value_provider.rs
+++ b/src/ga/value_provider.rs
@@ -1,6 +1,6 @@
 pub mod flat;
 
-use num_traits::{Float, Num};
+
 
 use super::Metrics;
 

--- a/src/ga/value_provider/flat.rs
+++ b/src/ga/value_provider/flat.rs
@@ -1,0 +1,65 @@
+use crate::ga::Metrics;
+
+use super::ValueProvider;
+
+pub struct FlatValue<T: Sized + Clone> {
+    value: T
+}
+
+impl <T: Sized + Clone> ValueProvider<T> for FlatValue<T> {
+    #[inline]
+    fn get(&mut self, _metrics: &Metrics) -> T {
+        self.value.clone()
+    }
+}
+
+// WE MUST ADD PLATFORM CHECKS HERE, TO VERIFY WHETHER GIVEN TYPES
+// ARE AVAILABLE ON GIVEN PLATFORM...
+
+impl ValueProvider<usize> for usize {
+    fn get(&mut self, metrics: &Metrics) -> usize {
+        *self
+    }
+}
+
+impl ValueProvider<isize> for isize {
+    fn get(&mut self, metrics: &Metrics) -> isize {
+        *self
+    }
+}
+
+impl ValueProvider<i32> for i32 {
+    fn get(&mut self, metrics: &Metrics) -> i32 {
+        *self
+    }
+}
+
+impl ValueProvider<i64> for i64 {
+    fn get(&mut self, metrics: &Metrics) -> i64 {
+        *self
+    }
+}
+
+impl ValueProvider<i8> for i8 {
+    fn get(&mut self, metrics: &Metrics) -> i8 {
+        *self
+    }
+}
+
+impl ValueProvider<u8> for u8 {
+    fn get(&mut self, metrics: &Metrics) -> u8 {
+        *self
+    }
+}
+
+impl ValueProvider<f32> for f32 {
+    fn get(&mut self, metrics: &Metrics) -> f32 {
+        *self
+    }
+}
+
+impl ValueProvider<f64> for f64 {
+    fn get(&mut self, metrics: &Metrics) -> f64 {
+        *self
+    }
+}

--- a/src/ga/value_provider/flat.rs
+++ b/src/ga/value_provider/flat.rs
@@ -17,49 +17,49 @@ impl<T: Sized + Clone> ValueProvider<T> for FlatValue<T> {
 // ARE AVAILABLE ON GIVEN PLATFORM...
 
 impl ValueProvider<usize> for usize {
-    fn get(&mut self, metrics: &Metrics) -> usize {
+    fn get(&mut self, _metrics: &Metrics) -> usize {
         *self
     }
 }
 
 impl ValueProvider<isize> for isize {
-    fn get(&mut self, metrics: &Metrics) -> isize {
+    fn get(&mut self, _metrics: &Metrics) -> isize {
         *self
     }
 }
 
 impl ValueProvider<i32> for i32 {
-    fn get(&mut self, metrics: &Metrics) -> i32 {
+    fn get(&mut self, _metrics: &Metrics) -> i32 {
         *self
     }
 }
 
 impl ValueProvider<i64> for i64 {
-    fn get(&mut self, metrics: &Metrics) -> i64 {
+    fn get(&mut self, _metrics: &Metrics) -> i64 {
         *self
     }
 }
 
 impl ValueProvider<i8> for i8 {
-    fn get(&mut self, metrics: &Metrics) -> i8 {
+    fn get(&mut self, _metrics: &Metrics) -> i8 {
         *self
     }
 }
 
 impl ValueProvider<u8> for u8 {
-    fn get(&mut self, metrics: &Metrics) -> u8 {
+    fn get(&mut self, _metrics: &Metrics) -> u8 {
         *self
     }
 }
 
 impl ValueProvider<f32> for f32 {
-    fn get(&mut self, metrics: &Metrics) -> f32 {
+    fn get(&mut self, _metrics: &Metrics) -> f32 {
         *self
     }
 }
 
 impl ValueProvider<f64> for f64 {
-    fn get(&mut self, metrics: &Metrics) -> f64 {
+    fn get(&mut self, _metrics: &Metrics) -> f64 {
         *self
     }
 }

--- a/src/ga/value_provider/flat.rs
+++ b/src/ga/value_provider/flat.rs
@@ -3,10 +3,10 @@ use crate::ga::Metrics;
 use super::ValueProvider;
 
 pub struct FlatValue<T: Sized + Clone> {
-    value: T
+    value: T,
 }
 
-impl <T: Sized + Clone> ValueProvider<T> for FlatValue<T> {
+impl<T: Sized + Clone> ValueProvider<T> for FlatValue<T> {
     #[inline]
     fn get(&mut self, _metrics: &Metrics) -> T {
         self.value.clone()

--- a/src/pso/particle.rs
+++ b/src/pso/particle.rs
@@ -89,7 +89,7 @@ impl Particle {
             updated_position.push(updated_x_i);
         }
 
-        self.position = updated_position.clone();
+        self.position.clone_from(&updated_position);
         self.value = function(&self.position);
 
         if self.value < self.best_position_value {

--- a/src/pso/swarm.rs
+++ b/src/pso/swarm.rs
@@ -36,7 +36,7 @@ impl Swarm {
         let mut best_position = particles[0].clone().best_position;
         for particle in &particles {
             if function(&particle.position) < function(&best_position) {
-                best_position = particle.position.clone();
+                best_position.clone_from(&particle.position);
             }
         }
 
@@ -74,7 +74,7 @@ impl Swarm {
     pub fn update_best_position(&mut self, function: fn(&Vec<f64>) -> f64) {
         self.particles.iter_mut().for_each(|particle| {
             if function(&particle.best_position) < function(&self.best_position) {
-                self.best_position = particle.best_position.clone();
+                self.best_position.clone_from(&particle.best_position);
                 self.best_position_value = particle.best_position_value;
             }
         });

--- a/tests/builder_tests.rs
+++ b/tests/builder_tests.rs
@@ -34,7 +34,7 @@ fn generic_does_not_panic_with_some_params_unspecified() {
         RealValueIndividual,
         Identity,
         SinglePoint,
-        Boltzmann,
+        Boltzmann<usize>,
         BothParents,
         RandomPoints,
         FnBasedFitness<RealValueIndividual>,
@@ -51,7 +51,7 @@ fn generic_does_not_panic_with_some_params_unspecified() {
         vec![-5.12..5.12, -5.12..5.12, -5.12..5.12],
     ))
     .set_selection_operator(ecrs::ga::operators::selection::Boltzmann::new(
-        0.05, 80.0, 500, false,
+        100, 0.05, 80.0, 500, false,
     ))
     .set_probe(ecrs::ga::probe::StdoutProbe)
     .build();
@@ -61,7 +61,7 @@ fn generic_does_not_panic_with_some_params_unspecified() {
         RealValueIndividual,
         Identity,
         SinglePoint,
-        Boltzmann,
+        Boltzmann<usize>,
         BothParents,
         RandomPoints,
         FnBasedFitness<RealValueIndividual>,
@@ -76,7 +76,7 @@ fn generic_does_not_panic_with_some_params_unspecified() {
         vec![-5.12..5.12, -5.12..5.12, -5.12..5.12],
     ))
     .set_selection_operator(ecrs::ga::operators::selection::Boltzmann::new(
-        0.05, 80.0, 500, false,
+        100, 0.05, 80.0, 500, false,
     ))
     .set_probe(ecrs::ga::probe::StdoutProbe)
     .build();

--- a/tests/selection_tests.rs
+++ b/tests/selection_tests.rs
@@ -26,7 +26,7 @@ fn random_selection_returns_demanded_size() {
 
     let expected_selection_size = expected_population_size / 2;
 
-    let selected = Random::new().apply(&metrics, &population, expected_selection_size);
+    let selected = Random::new(expected_selection_size).apply(&metrics, &population);
 
     assert_eq!(
         expected_selection_size,
@@ -51,7 +51,7 @@ fn roulette_whell_returns_demanded_size() {
 
     let expected_selection_size = expected_population_size / 2;
 
-    let selected = RouletteWheel::new().apply(&metrics, &population, expected_selection_size);
+    let selected = RouletteWheel::new(expected_selection_size).apply(&metrics, &population);
 
     assert_eq!(
         expected_selection_size,
@@ -76,7 +76,7 @@ fn rank_returns_demanded_size() {
 
     let expected_selection_size = expected_population_size / 2;
 
-    let selected = Rank::new().apply(&metrics, &population, expected_selection_size);
+    let selected = Rank::new(expected_selection_size).apply(&metrics, &population);
 
     assert_eq!(
         expected_selection_size,
@@ -101,7 +101,7 @@ fn rankr_returns_demanded_size() {
 
     let expected_selection_size = expected_population_size / 2;
 
-    let selected = RankR::new(0.5).apply(&metrics, &population, expected_selection_size);
+    let selected = RankR::new(0.5, expected_selection_size).apply(&metrics, &population);
 
     assert_eq!(
         expected_selection_size,
@@ -126,7 +126,7 @@ fn tournament_returns_demanded_size() {
 
     let expected_selection_size = expected_population_size / 2;
 
-    let selected = Tournament::new(0.2).apply(&metrics, &population, expected_selection_size);
+    let selected = Tournament::new(0.2, expected_selection_size).apply(&metrics, &population);
 
     assert_eq!(
         expected_selection_size,
@@ -156,7 +156,7 @@ fn sus_returns_demanded_size_when_fitness_positive() {
 
     let expected_selection_size = expected_population_size / 2;
 
-    let selected = StochasticUniversalSampling::new().apply(&metrics, &population, expected_selection_size);
+    let selected = StochasticUniversalSampling::new(expected_selection_size).apply(&metrics, &population);
 
     assert_eq!(
         expected_selection_size,
@@ -188,7 +188,7 @@ fn boltzmann_returns_demanded_size() {
     // FIXME: We must add mocking!
     let metrics = Metrics::new(Some(std::time::Instant::now()), None, 40);
 
-    let selected = Boltzmann::new(0.2, 6.0, 300, true).apply(&metrics, &population, expected_selection_size);
+    let selected = Boltzmann::new(expected_selection_size, 0.2, 6.0, 300, true).apply(&metrics, &population);
 
     assert_eq!(
         expected_selection_size,
@@ -203,9 +203,9 @@ fn random_returns_whole_population_in_order() {
     let dim = 21;
 
     let population: Vec<RealValueIndividual> = RandomPoints::new(dim).generate(population_size);
-    let mut operator = Random::with_rng(rand::rngs::mock::StepRng::new(0, 1));
+    let mut operator = Random::with_rng(population_size, rand::rngs::mock::StepRng::new(0, 1));
 
-    let selected = operator.apply(&Metrics::default(), &population, population_size);
+    let selected = operator.apply(&Metrics::default(), &population);
 
     for (expected, actual) in std::iter::zip(&population, selected) {
         assert_eq!(expected, actual);


### PR DESCRIPTION
- **Add ValueProvider trait**
- **Migrate RouletteWheel**
- **Migrate Random**
- **Migrate Rank**
- **Migrate RankR**
- **Migrate Tournament**
- **Migrate SUS**
- **Migrate Boltzmann**
- **Update docs**
- **Fix tests in selection impls module**
- **Fix leftovers**

<!-- If applicable - remember to add the PR to the EA Rust project (ONLY IF THERE IS NO LINKED ISSUE) -->

## Description

## Linked issues <!-- Please use "Resolves #<issue_no> syntax in case this PR should be linked to an issue -->

Closes #193 

## Important implementation details <!-- if any, optional section -->

